### PR TITLE
Add client_secret_jwt client authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,14 @@ oauth2c https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
   --auth-method client_secret_post \
   --scopes introspect_tokens,revoke_tokens
 ```
+
+### Client Secret JWT
+
+``` sh
+oauth2c https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
+  --client-id ab966ce4f2ac4f4aa641582b099c32d3 \
+  --client-secret 578-WfFYfBheWb8gJpHYXMRRqR5HN0qv7d7xIolJnIE \
+  --grant-type client_credentials \
+  --auth-method client_secret_jwt \
+  --scopes introspect_tokens,revoke_tokens
+```

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -128,3 +128,21 @@ func LogAssertion(request oauth2.Request) {
 		}
 	}
 }
+
+func LogClientAssertion(request oauth2.Request) {
+	assertion := request.Form.Get("client_assertion")
+
+	if assertion != "" {
+		var claims jwt.MapClaims
+
+		if _, _, err := parser.ParseUnverified(assertion, &claims); err != nil {
+			pterm.Error.Println(err)
+		} else {
+			pterm.DefaultBox.WithTitle("client_assertion").Printfln("client_assertion = JWT-HS256(payload)")
+			pterm.Println("")
+			pterm.Println("Payload")
+			LogJson(claims)
+			pterm.Println("")
+		}
+	}
+}

--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/cloudentity/oauth2c/internal/oauth2"
-	"github.com/go-jose/go-jose/v3"
 	"github.com/golang-jwt/jwt"
 	"github.com/imdario/mergo"
 	"github.com/pkg/browser"
@@ -365,37 +364,7 @@ func RefreshTokenGrantFlow(clientConfig oauth2.ClientConfig, serverConfig oauth2
 }
 
 func JWTBearerGrantFlow(clientConfig oauth2.ClientConfig, serverConfig oauth2.ServerConfig, hc *http.Client) error {
-	var (
-		extraClaims map[string]interface{}
-		key         jose.JSONWebKey
-		assertion   string
-		err         error
-	)
-
-	if clientConfig.Assertion == "" {
-		clientConfig.Assertion = "{}"
-	}
-
-	if err = json.Unmarshal([]byte(clientConfig.Assertion), &extraClaims); err != nil {
-		return fmt.Errorf("failed to parse assertion extra claims, it must be a valid JSON: %+v", err)
-	}
-
-	if clientConfig.SigningKey == "" {
-		return errors.New("path to signing key must be provided")
-	}
-
-	if key, err = oauth2.ReadKey(clientConfig.SigningKey, hc); err != nil {
-		return fmt.Errorf("failed to read signing key: %s, %+v", clientConfig.SigningKey, err)
-	}
-
-	if assertion, err = oauth2.SignJWT(
-		oauth2.AssertionClaims(extraClaims, serverConfig),
-		oauth2.JWKSigner(key),
-	); err != nil {
-		return fmt.Errorf("failed to sign assertion: %s", clientConfig.SigningKey)
-	}
-
-	return tokenEndpointFlow("JWT Bearer Grant Flow", clientConfig, serverConfig, hc, oauth2.WithAssertion(assertion))
+	return tokenEndpointFlow("JWT Bearer Grant Flow", clientConfig, serverConfig, hc)
 }
 
 func tokenEndpointFlow(

--- a/internal/oauth2/signing.go
+++ b/internal/oauth2/signing.go
@@ -52,7 +52,29 @@ func ReadKey(location string, hc *http.Client) (jose.JSONWebKey, error) {
 	return keys.Keys[0], nil
 }
 
-func SignJWT(claims map[string]interface{}, key jose.JSONWebKey) (string, error) {
+type SignerProvider func() (jose.Signer, error)
+
+func JWKSigner(key jose.JSONWebKey) SignerProvider {
+	return func() (jose.Signer, error) {
+		return jose.NewSigner(jose.SigningKey{
+			Algorithm: jose.SignatureAlgorithm(key.Algorithm),
+			Key:       key.Key,
+		}, &jose.SignerOptions{
+			ExtraHeaders: map[jose.HeaderKey]interface{}{"kid": key.KeyID},
+		})
+	}
+}
+
+func SecretSigner(secret []byte) SignerProvider {
+	return func() (jose.Signer, error) {
+		return jose.NewSigner(jose.SigningKey{
+			Algorithm: jose.HS256,
+			Key:       secret,
+		}, nil)
+	}
+}
+
+func SignJWT(claims map[string]interface{}, provider SignerProvider) (string, error) {
 	var (
 		signer jose.Signer
 		jws    *jose.JSONWebSignature
@@ -60,12 +82,7 @@ func SignJWT(claims map[string]interface{}, key jose.JSONWebKey) (string, error)
 		err    error
 	)
 
-	if signer, err = jose.NewSigner(jose.SigningKey{
-		Algorithm: jose.SignatureAlgorithm(key.Algorithm),
-		Key:       key.Key,
-	}, &jose.SignerOptions{
-		ExtraHeaders: map[jose.HeaderKey]interface{}{"kid": key.KeyID},
-	}); err != nil {
+	if signer, err = provider(); err != nil {
 		return "", errors.Wrapf(err, "failed to create signer")
 	}
 
@@ -80,7 +97,7 @@ func SignJWT(claims map[string]interface{}, key jose.JSONWebKey) (string, error)
 	return jws.CompactSerialize()
 }
 
-func WithStandardClaims(extra map[string]interface{}, serverConfig ServerConfig) map[string]interface{} {
+func AssertionClaims(extra map[string]interface{}, serverConfig ServerConfig) map[string]interface{} {
 	claims := map[string]interface{}{
 		"iss": serverConfig.TokenEndpoint,
 		"aud": serverConfig.TokenEndpoint,
@@ -94,4 +111,15 @@ func WithStandardClaims(extra map[string]interface{}, serverConfig ServerConfig)
 	}
 
 	return claims
+}
+
+func ClientAssertionClaims(serverConfig ServerConfig, clientConfig ClientConfig) map[string]interface{} {
+	return map[string]interface{}{
+		"iss": clientConfig.ClientID,
+		"sub": clientConfig.ClientID,
+		"aud": serverConfig.TokenEndpoint,
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Minute * 10).Unix(),
+		"jti": RandomString(20),
+	}
 }

--- a/internal/oauth2/signing_test.go
+++ b/internal/oauth2/signing_test.go
@@ -23,16 +23,18 @@ func TestSignJWT(t *testing.T) {
 	require.NoError(t, err)
 
 	claims := oauth2.AssertionClaims(
-		map[string]interface{}{
-			"sub": "jdoe@example.com",
-		},
 		oauth2.ServerConfig{
 			Issuer:        "https://example.com/tid/aid",
 			TokenEndpoint: "https://example.com/tid/aid/oauth2/token",
 		},
+		oauth2.ClientConfig{
+			Assertion: `{"sub": "jdoe@example.com"}`,
+		},
 	)
 
-	jwt, err := oauth2.SignJWT(claims, oauth2.JWKSigner(key))
+	jwt, err := oauth2.SignJWT(claims, oauth2.JWKSigner(oauth2.ClientConfig{
+		SigningKey: "./testdata/jwks-private.json",
+	}, http.DefaultClient))
 	require.NoError(t, err)
 
 	jws, err := jose.ParseSigned(jwt)

--- a/internal/oauth2/signing_test.go
+++ b/internal/oauth2/signing_test.go
@@ -22,16 +22,17 @@ func TestSignJWT(t *testing.T) {
 	key, err := oauth2.ReadKey("./testdata/jwks-private.json", http.DefaultClient)
 	require.NoError(t, err)
 
-	claims := oauth2.WithStandardClaims(
+	claims := oauth2.AssertionClaims(
 		map[string]interface{}{
 			"sub": "jdoe@example.com",
 		},
 		oauth2.ServerConfig{
 			Issuer:        "https://example.com/tid/aid",
 			TokenEndpoint: "https://example.com/tid/aid/oauth2/token",
-		})
+		},
+	)
 
-	jwt, err := oauth2.SignJWT(claims, key)
+	jwt, err := oauth2.SignJWT(claims, oauth2.JWKSigner(key))
 	require.NoError(t, err)
 
 	jws, err := jose.ParseSigned(jwt)
@@ -40,7 +41,7 @@ func TestSignJWT(t *testing.T) {
 	bs, err := jws.Verify(key.Public())
 	require.NoError(t, err)
 
-	var m map[string]interface{}
+	m := map[string]interface{}{}
 
 	err = json.Unmarshal(bs, &m)
 	require.NoError(t, err)


### PR DESCRIPTION
```

oauth2c on  feature/client_secret_jwt via 🐹 v1.19.3 took 3s
[I] ➜ go run . https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
  --client-id ab966ce4f2ac4f4aa641582b099c32d3 \
  --client-secret 578-WfFYfBheWb8gJpHYXMRRqR5HN0qv7d7xIolJnIE \
  --grant-type client_credentials \
  --auth-method client_secret_jwt \
  --scopes introspect_tokens,revoke_tokens

┌──────────────────────────────────────────────────────────────────────┐
| Issuer URL    | https://oauth2c.us.authz.cloudentity.io/oauth2c/demo |
| Grant type    | client_credentials                                   |
| Auth method   | client_secret_jwt                                    |
| Scopes        | introspect_tokens, revoke_tokens                     |
| PKCE          | false                                                |
| Client ID     | ab966ce4f2ac4f4aa641582b099c32d3                     |
| Client secret | 578-WfFYfBheWb8gJpHYXMRRqR5HN0qv7d7xIolJnIE          |
└──────────────────────────────────────────────────────────────────────┘


 Client Credentials Flow


# Request authorization

┌─ client_assertion ────────────────────┐
| client_assertion = JWT-HS256(payload) |
└───────────────────────────────────────┘

Payload
{
  "aud": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token",
  "exp": 1668590128,
  "iat": 1668589528,
  "iss": "ab966ce4f2ac4f4aa641582b099c32d3",
  "jti": "gW3QgKElkcS9qEqo6kbj",
  "sub": "ab966ce4f2ac4f4aa641582b099c32d3"
}

POST https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token
Headers:
  Content-Type: application/x-www-form-urlencoded
Form post:
  client_assertion_type: urn:ietf:params:oauth:client-assertion-type:jwt-bearer
  client_assertion: eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJodHRwczovL29hdXRoMmMudXMuYXV0aHouY2xvdWRlbnRpdHkuaW8vb2F1dGgyYy9kZW1vL29hdXRoMi90b2tlbiIsImV4cCI6MTY2ODU5MDEyOCwiaWF0IjoxNjY4NTg5NTI4LCJpc3MiOiJhYjk2NmNlNGYyYWM0ZjRhYTY0MTU4MmIwOTljMzJkMyIsImp0aSI6ImdXM1FnS0Vsa2NTOXFFcW82a2JqIiwic3ViIjoiYWI5NjZjZTRmMmFjNGY0YWE2NDE1ODJiMDk5YzMyZDMifQ.eqfd3XDvs1r6iXVWJ25rYtYGfECAOliIEajtwYa97t4
  grant_type: client_credentials
  scope: introspect_tokens revoke_tokens
Response:
{
  "access_token": "eyJhbGciOiJFUzI1NiIsImtpZCI6IjU5NzU4NjA1NjEwNDY4NjgzMDgzNzIyNjM3OTQyMzEwNjY2NTg0IiwidHlwIjoiSldUIn0.eyJhaWQiOiJkZW1vIiwiYW1yIjpbXSwiYXVkIjpbImFiOTY2Y2U0ZjJhYzRmNGFhNjQxNTgyYjA5OWMzMmQzIiwic3BpZmZlOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8vZGVtby1vYXV0aDIiXSwiZXhwIjoxNjY4NTkzMTI4LCJpYXQiOjE2Njg1ODk1MjgsImlkcCI6IiIsImlzcyI6Imh0dHBzOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8iLCJqdGkiOiI2Y2UyZWQ4ZC0wODM0LTQzNTEtOTZiMS1iNDY4ZTZlZjMyODUiLCJuYmYiOjE2Njg1ODk1MjgsInNjcCI6WyJpbnRyb3NwZWN0X3Rva2VucyIsInJldm9rZV90b2tlbnMiXSwic3QiOiJwdWJsaWMiLCJzdWIiOiJhYjk2NmNlNGYyYWM0ZjRhYTY0MTU4MmIwOTljMzJkMyIsInRpZCI6Im9hdXRoMmMifQ.9VoOop3scoPpF-g1oE90HU60mL964hV597raOJW2ezQ0wtaReTxc_65Sj7HnRd83AcElKOpB0TJTHIl-PmB5JA",
  "expires_in": 3599,
  "scope": "introspect_tokens revoke_tokens",
  "token_type": "bearer"
}
Access token:
{
  "aid": "demo",
  "amr": [],
  "aud": [
    "ab966ce4f2ac4f4aa641582b099c32d3",
    "spiffe://oauth2c.us.authz.cloudentity.io/oauth2c/demo/demo-oauth2"
  ],
  "exp": 1668593128,
  "iat": 1668589528,
  "idp": "",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "6ce2ed8d-0834-4351-96b1-b468e6ef3285",
  "nbf": 1668589528,
  "scp": ["introspect_tokens", "revoke_tokens"],
  "st": "public",
  "sub": "ab966ce4f2ac4f4aa641582b099c32d3",
  "tid": "oauth2c"
}

 SUCCESS  Authorization completed

```