### PR TITLE
Add private_key_jwt client authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,14 @@ oauth2c https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
   --auth-method client_secret_jwt \
   --scopes introspect_tokens,revoke_tokens
 ```
+
+### Private Key JWT
+
+``` sh
+oauth2c https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
+  --client-id 582af0afb0d74554aa7af47849edb222 \
+  --signing-key https://pastebin.com/raw/WMkzhjhm \
+  --grant-type client_credentials \
+  --auth-method private_key_jwt \
+  --scopes introspect_tokens,revoke_tokens
+```

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"strings"
 
 	"github.com/cloudentity/oauth2c/internal/oauth2"
@@ -135,13 +140,49 @@ func LogClientAssertion(request oauth2.Request) {
 	if assertion != "" {
 		var claims jwt.MapClaims
 
-		if _, _, err := parser.ParseUnverified(assertion, &claims); err != nil {
+		if token, _, err := parser.ParseUnverified(assertion, &claims); err != nil {
 			pterm.Error.Println(err)
 		} else {
-			pterm.DefaultBox.WithTitle("client_assertion").Printfln("client_assertion = JWT-HS256(payload)")
+			pterm.DefaultBox.WithTitle("Client assertion").Printfln("client_assertion = JWT-%s(payload)", token.Header["alg"])
 			pterm.Println("")
 			pterm.Println("Payload")
 			LogJson(claims)
+			pterm.Println("")
+
+			pterm.Println("Key")
+			switch key := request.Key.(type) {
+			case *rsa.PrivateKey:
+				p := bytes.Buffer{}
+
+				if err = pem.Encode(&p, &pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(key),
+				}); err != nil {
+					pterm.Error.Println(err)
+				}
+
+				pterm.FgGray.Printfln(p.String())
+			case *ecdsa.PrivateKey:
+				b, err := x509.MarshalECPrivateKey(key)
+
+				if err != nil {
+					pterm.Error.Println(err)
+				}
+
+				p := bytes.Buffer{}
+
+				if err = pem.Encode(&p, &pem.Block{
+					Type:  "EC PRIVATE KEY",
+					Bytes: b,
+				}); err != nil {
+					pterm.Error.Println(err)
+				}
+
+				pterm.FgGray.Printfln(p.String())
+			case []byte:
+				pterm.FgGray.Println(string(key))
+			}
+
 			pterm.Println("")
 		}
 	}

--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -399,8 +399,8 @@ func tokenEndpointFlow(
 		return err
 	}
 
-	LogAssertion(tokenRequest)
-	LogClientAssertion(tokenRequest)
+	LogAssertion(tokenRequest, "Assertion", "assertion")
+	LogAssertion(tokenRequest, "Client assertion", "client_assertion")
 	LogAuthMethod(clientConfig)
 	LogRequestAndResponse(tokenRequest, tokenResponse)
 	LogTokenPayloadln(tokenResponse)

--- a/internal/oauth2/signing_test.go
+++ b/internal/oauth2/signing_test.go
@@ -32,7 +32,7 @@ func TestSignJWT(t *testing.T) {
 		},
 	)
 
-	jwt, err := oauth2.SignJWT(claims, oauth2.JWKSigner(oauth2.ClientConfig{
+	jwt, _, err := oauth2.SignJWT(claims, oauth2.JWKSigner(oauth2.ClientConfig{
 		SigningKey: "./testdata/jwks-private.json",
 	}, http.DefaultClient))
 	require.NoError(t, err)

--- a/internal/oauth2/tracing.go
+++ b/internal/oauth2/tracing.go
@@ -7,6 +7,7 @@ type Request struct {
 	URL     *url.URL
 	Headers map[string][]string
 	Form    url.Values
+	Key     interface{}
 }
 
 func (r *Request) Get(key string) string {


### PR DESCRIPTION
```

oauth2c on  feature/private_key_jwt via 🐹 v1.19.3 took 3s
[I] ➜ go run . https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
  --client-id 582af0afb0d74554aa7af47849edb222 \
  --signing-key https://pastebin.com/raw/WMkzhjhm \
  --grant-type client_credentials \
  --auth-method private_key_jwt \
  --scopes introspect_tokens,revoke_tokens

┌────────────────────────────────────────────────────────────────────┐
| Issuer URL  | https://oauth2c.us.authz.cloudentity.io/oauth2c/demo |
| Grant type  | client_credentials                                   |
| Auth method | private_key_jwt                                      |
| Scopes      | introspect_tokens, revoke_tokens                     |
| PKCE        | false                                                |
| Client ID   | 582af0afb0d74554aa7af47849edb222                     |
└────────────────────────────────────────────────────────────────────┘


                                                                                               Client Credentials Flow


# Request authorization

┌─ Client assertion ────────────────────┐
| client_assertion = JWT-RS256(payload) |
└───────────────────────────────────────┘

Payload
{
  "aud": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token",
  "exp": 1668600403,
  "iat": 1668599803,
  "iss": "582af0afb0d74554aa7af47849edb222",
  "jti": "RIvBvYxo7CFVsmA8j2Ii",
  "sub": "582af0afb0d74554aa7af47849edb222"
}

Key
-----BEGIN RSA PRIVATE KEY-----
MIIEpAIBAAKCAQEA4b/IX1bV29pw6/Ce8DdkoNx4dxJnDD9AyxmTG2z99cvlHG6B
JaMF6l09ncGXGbv3dufDKrhftkwfbTBdpUEAeext/ugCmXTV06Fayva6Iq7xCNE8
pA6hJT1y3Edsqq3IU8KVivYjYwd/vrSUfCe8pQRsR6K8rqnJ66ryn0yewkTEyCgP
Iv6pOMbgq1d5iX/2G9rZNhj74miN5y4fy0tsbI3q2RUOzt2d+htkoysqu3Xta6qP
A3vEJ2FnQo3dhgw4XSCEvjz+HSGnsTC+XBv6j6jI9SD5jI2UYqnyDcYmRHPJx2sQ
/c8aLYHRdZxrxqIxUzulS6g0x74E2m0gBMKF5wIDAQABAoIBACvTYp/3qK702mVD
omd6KYP9KTncjbrX8Mk9Hsz9PNRiEAmT/miDHJviHBsrQR1S23jvB3mcr6AhaRx2
fkedtez1lGkfO5n1D6n1Mj4i5gHjupF+pWooGOq04j6XcyYzdKemKAgBPt9zzj4E
qqrrv/i9QhQqKL0z4ypoVo/MfSmzeK8//37jT2VR0DTHoNCrZI4zbTnF/SdMJQkh
WjQwbXAxZKsncY8UWeQkWazoaTRMunznniajnHABWmPE+ITZ1TMdjkZIEboV3xlQ
Ku9iw9SfSrARDuPC7vZqIHIZ3PwFc8Q6Vd+EEH/ORIv3ndMXjxAbgJEpdCMKMVl/
uyA6dFECgYEA9cpYDIDGiJuTfG8jvqftdMD6rd11tuNMlHAO/3vXkep9B+e4lBbL
dmvkNng/8aCVKeLTGJWJ+7fQLjfUSqqS+qUrU27catGrCq/98VIgvmZM/6Gyr1IB
V1AK9LhqMZH9ZhQ8rOqsjc2Iu3kGQep7ZJ96/CJnCdU5rQmR8WwCDO8CgYEA6yBT
lj5xYtwnwEHCQWeIs6pvQvbdhXqLvXqdZi4J9skoMH+YOXng6z4rUAazAKvZ95hV
LYFyUIrQvKvY0NqUySiPX09ezfbxY1/ShEpQe8bIeVuQmOKuyrzseoB47a1c8MuL
tdRbytp0Vx0ed7bRvq877cfZIs76AMdG5cJkBokCgYEAytkm15LDxuRW0SBMKMIg
h/XoLOuThc+LWQouZo2HeIZEj+yeeaFiY6ZhXs7ZPwofcMUhIK3xhcvKxQoQa1rh
GHiODDp3MLU/av+aHbqBCYIWU/bYKDcOokeN8y/rfGOW9NMIzFCU/ia9jLMyBd6F
3aJ89m9SCFxwUC2Qw+U2wAMCgYAJrQ3ji/RMljTIk6wz1tfoVOY5QkGBgbaIeKhL
kS91yXdu74FLNDnOVIOhynTJXUkeCFXRBpe2us+2Q/grOCORV6r2yCRlo3jxlvrp
2MkRHvAXFm6P7Bw3Waj9rZXMair9+dJpDDEu2uiYwSkE0jA1ga6crXHBHfVp3MmN
IP/OyQKBgQDLPoNJS9QYuGZhfXmCPrirOW2g+vuikXCJfLK9uh6FMpcagiL6VQQt
vA5xqPbdyIJDYFnJ3ua7IT7ct50m6QvLwca/JVWenjBC1GzV0ilI/jKfaeRdMwBK
o3bEPhsBtELzF6IX6QYDzMoumvQsq5lsGd8AbSqFOXMQfBMUBDxDYg==
-----END RSA PRIVATE KEY-----


POST https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token
Headers:
  Content-Type: application/x-www-form-urlencoded
Form post:
  grant_type: client_credentials
  scope: introspect_tokens revoke_tokens
  client_assertion_type: urn:ietf:params:oauth:client-assertion-type:jwt-bearer
  client_assertion: eyJhbGciOiJSUzI1NiIsImtpZCI6IjE2NzQ2NzIwMDM0NjUxODg3Mzk5MDA1NTYzMTkyMTgxMjM0Nzk3NTE4MDAwMzI0NSJ9.eyJhdWQiOiJodHRwczovL29hdXRoMmMudXMuYXV0aHouY2xvdWRlbnRpdHkuaW8vb2F1dGgyYy9kZW1vL29hdXRoMi90b2tlbiIsImV4cCI6MTY2ODYwMDQwMywiaWF0IjoxNjY4NTk5ODAzLCJpc3MiOiI1ODJhZjBhZmIwZDc0NTU0YWE3YWY0Nzg0OWVkYjIyMiIsImp0aSI6IlJJdkJ2WXhvN0NGVnNtQThqMklpIiwic3ViIjoiNTgyYWYwYWZiMGQ3NDU1NGFhN2FmNDc4NDllZGIyMjIifQ.sBpjRXzP8fzIKFJTOJu7krLGMv6B13HEeY71ShY9r60wu7c8ZcDySJAIOD-UbIkn50kV_P3KsWLdrBrvMvdyQ4NN7m3nMApq4o77kmUtnKJNBIcmxJAKGTSU3WWnA0i9KO6rWYwI2BekOvuCLbHr_vtQMRcE2xhH7KjvuCd7TKvA-uYQhOSv04J1lXxgGKYnuzU_25C0m_lJHsmqpAJpe9tlTSmKGAxPaT0k1Xrtlqg2ljIEIL6xQJmGkrFQaelTj4DFNra3rCWI0uqKYCrzeV01squ0Jg6D7fSIxowdu9Z7ADQMhO747s4h55dUDme38B2jiJ0ByImP_k9pSYgMCg
Response:
{
  "access_token": "eyJhbGciOiJFUzI1NiIsImtpZCI6IjU5NzU4NjA1NjEwNDY4NjgzMDgzNzIyNjM3OTQyMzEwNjY2NTg0IiwidHlwIjoiSldUIn0.eyJhaWQiOiJkZW1vIiwiYW1yIjpbXSwiYXVkIjpbIjU4MmFmMGFmYjBkNzQ1NTRhYTdhZjQ3ODQ5ZWRiMjIyIiwic3BpZmZlOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8vZGVtby1vYXV0aDIiXSwiZXhwIjoxNjY4NjAzNDAzLCJpYXQiOjE2Njg1OTk4MDMsImlkcCI6IiIsImlzcyI6Imh0dHBzOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8iLCJqdGkiOiJkMzBkZGJkZC1lYTY4LTRiODktYWQ5Zi0wMTgzMWMwNTM1YmYiLCJuYmYiOjE2Njg1OTk4MDMsInNjcCI6WyJpbnRyb3NwZWN0X3Rva2VucyIsInJldm9rZV90b2tlbnMiXSwic3QiOiJwdWJsaWMiLCJzdWIiOiI1ODJhZjBhZmIwZDc0NTU0YWE3YWY0Nzg0OWVkYjIyMiIsInRpZCI6Im9hdXRoMmMifQ.ysw2OEAfWAcAkS1is4x7kAVjBpPKgnk7_ucUZ-6yMV_OctamA3tXl2jYwm5teZQQs6GDsT8Yp8n8eaijBtqPmA",
  "expires_in": 3599,
  "scope": "introspect_tokens revoke_tokens",
  "token_type": "bearer"
}
Access token:
{
  "aid": "demo",
  "amr": [],
  "aud": [
    "582af0afb0d74554aa7af47849edb222",
    "spiffe://oauth2c.us.authz.cloudentity.io/oauth2c/demo/demo-oauth2"
  ],
  "exp": 1668603403,
  "iat": 1668599803,
  "idp": "",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "d30ddbdd-ea68-4b89-ad9f-01831c0535bf",
  "nbf": 1668599803,
  "scp": ["introspect_tokens", "revoke_tokens"],
  "st": "public",
  "sub": "582af0afb0d74554aa7af47849edb222",
  "tid": "oauth2c"
}

 SUCCESS  Authorization completed

```