### PR TITLE
[doc] Add homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Alternatively, you can download a pre-built binary from the [releases page].
 
 [releases page]: https://github.com/cloudentity/oauth2c/releases
 
+If using homebrew:
+```sh
+brew install oauth2c
+```
+
 ## Usage
 
 To use `oauth2c`, run the following command and follow the prompts:


### PR DESCRIPTION
This PR depends on https://github.com/Homebrew/homebrew-core/pull/117756, as in `brew install oauth2c` will only work when the PR is accepted on homebrew-core repository.

Nice tool! Thanks!