### PR TITLE
Add support for encrypted request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The available flags are:
       --auth-method string          token endpoint authentication method
       --client-id string            client identifier
       --client-secret string        client secret
+      --encrypted-request-object    pass request parameters as encrypted jwt
       --encryption-key string       path or url to encryption key in jwks format
       --grant-type string           grant type
   -h, --help                        help for oauthc

--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -58,6 +58,7 @@ func NewOAuth2Cmd() (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().BoolVar(&cconfig.PKCE, "pkce", false, "enable proof key for code exchange (PKCE)")
 	cmd.PersistentFlags().BoolVar(&cconfig.PAR, "par", false, "enable pushed authorization requests (PAR)")
 	cmd.PersistentFlags().BoolVar(&cconfig.RequestObject, "request-object", false, "pass request parameters as jwt")
+	cmd.PersistentFlags().BoolVar(&cconfig.EncryptedRequestObject, "encrypted-request-object", false, "pass request parameters as encrypted jwt")
 	cmd.PersistentFlags().StringVar(&cconfig.Assertion, "assertion", "", "claims for jwt bearer assertion")
 	cmd.PersistentFlags().StringVar(&cconfig.SigningKey, "signing-key", "", "path or url to signing key in jwks format")
 	cmd.PersistentFlags().StringVar(&cconfig.EncryptionKey, "encryption-key", "", "path or url to encryption key in jwks format")

--- a/internal/oauth2/jwe.go
+++ b/internal/oauth2/jwe.go
@@ -9,16 +9,16 @@ import (
 
 type EncrypterProvider func() (jose.Encrypter, interface{}, error)
 
-func JWEEncrypter(clientConfig ClientConfig, hc *http.Client) EncrypterProvider {
+func JWEEncrypter(keyPath string, hc *http.Client) EncrypterProvider {
 	return func() (encrypter jose.Encrypter, _ interface{}, err error) {
 		var key jose.JSONWebKey
 
-		if clientConfig.EncryptionKey == "" {
+		if keyPath == "" {
 			return nil, nil, errors.New("no encryption key path")
 		}
 
-		if key, err = ReadKey(EncryptionKey, clientConfig.EncryptionKey, hc); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to read encryption key from %s", clientConfig.EncryptionKey)
+		if key, err = ReadKey(EncryptionKey, keyPath, hc); err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to read encryption key from %s", keyPath)
 		}
 
 		if encrypter, err = jose.NewEncrypter(

--- a/internal/oauth2/jwt.go
+++ b/internal/oauth2/jwt.go
@@ -32,16 +32,16 @@ func UnsafeParseJWT(token string) (*jwt.JSONWebToken, map[string]interface{}, er
 
 type SignerProvider func() (jose.Signer, interface{}, error)
 
-func JWKSigner(clientConfig ClientConfig, hc *http.Client) SignerProvider {
+func JWKSigner(keyPath string, hc *http.Client) SignerProvider {
 	return func() (signer jose.Signer, _ interface{}, err error) {
 		var key jose.JSONWebKey
 
-		if clientConfig.SigningKey == "" {
+		if keyPath == "" {
 			return nil, nil, errors.New("no signing key path")
 		}
 
-		if key, err = ReadKey(SigningKey, clientConfig.SigningKey, hc); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to read signing key from %s", clientConfig.SigningKey)
+		if key, err = ReadKey(SigningKey, keyPath, hc); err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to read signing key from %s", keyPath)
 		}
 
 		if signer, err = jose.NewSigner(jose.SigningKey{

--- a/internal/oauth2/jwt_test.go
+++ b/internal/oauth2/jwt_test.go
@@ -23,9 +23,7 @@ func TestSignJWT(t *testing.T) {
 		},
 	)
 
-	jwt, _, err := SignJWT(claims, JWKSigner(ClientConfig{
-		SigningKey: "../../data/key.json",
-	}, http.DefaultClient))
+	jwt, _, err := SignJWT(claims, JWKSigner("../../data/key.json", http.DefaultClient))
 	require.NoError(t, err)
 
 	jws, err := jose.ParseSigned(jwt)

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -54,31 +54,32 @@ const CodeVerifierLength = 43
 var CodeChallengeEncoder = base64.RawURLEncoding
 
 type ClientConfig struct {
-	IssuerURL        string
-	GrantType        string
-	ClientID         string
-	ClientSecret     string
-	Scopes           []string
-	AuthMethod       string
-	PKCE             bool
-	PAR              bool
-	RequestObject    bool
-	Insecure         bool
-	ResponseType     []string
-	ResponseMode     string
-	Username         string
-	Password         string
-	RefreshToken     string
-	Assertion        string
-	SigningKey       string
-	EncryptionKey    string
-	SubjectToken     string
-	SubjectTokenType string
-	ActorToken       string
-	ActorTokenType   string
-	TLSCert          string
-	TLSKey           string
-	TLSRootCA        string
+	IssuerURL              string
+	GrantType              string
+	ClientID               string
+	ClientSecret           string
+	Scopes                 []string
+	AuthMethod             string
+	PKCE                   bool
+	PAR                    bool
+	RequestObject          bool
+	EncryptedRequestObject bool
+	Insecure               bool
+	ResponseType           []string
+	ResponseMode           string
+	Username               string
+	Password               string
+	RefreshToken           string
+	Assertion              string
+	SigningKey             string
+	EncryptionKey          string
+	SubjectToken           string
+	SubjectTokenType       string
+	ActorToken             string
+	ActorTokenType         string
+	TLSCert                string
+	TLSKey                 string
+	TLSRootCA              string
 }
 
 func RequestAuthorization(addr string, cconfig ClientConfig, sconfig ServerConfig, hc *http.Client) (r Request, codeVerifier string, err error) {
@@ -358,7 +359,7 @@ func RequestToken(
 
 		if assertion, request.SigningKey, err = SignJWT(
 			AssertionClaims(sconfig, cconfig),
-			JWKSigner(cconfig, hc),
+			JWKSigner(cconfig.SigningKey, hc),
 		); err != nil {
 			return request, response, err
 		}


### PR DESCRIPTION
```
go run . https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
  --client-id cauktionbud6q8ftlqq0 \
  --client-secret HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc \
  --response-types code \
  --response-mode query \
  --grant-type authorization_code \
  --auth-method client_secret_basic \
  --scopes openid,email,offline_access \
  --encrypted-request-object

┌───────────────────────────────────────────────────────────────────────┐
| Issuer URL     | https://oauth2c.us.authz.cloudentity.io/oauth2c/demo |
| Grant type     | authorization_code                                   |
| Auth method    | client_secret_basic                                  |
| Scopes         | openid, email, offline_access                        |
| Response types | code                                                 |
| Response mode  | query                                                |
| PKCE           | false                                                |
| Client ID      | cauktionbud6q8ftlqq0                                 |
| Client secret  | HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc          |
└───────────────────────────────────────────────────────────────────────┘


                     Authorization Code Flow


# Request authorization

┌─ Request object ──────────────────────────────┐
| request = JWE-RSA-OAEP-256(JWT-none(payload)) |
└───────────────────────────────────────────────┘

Payload
{
  "aud": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "client_id": "cauktionbud6q8ftlqq0",
  "iss": "cauktionbud6q8ftlqq0",
  "nonce": "cMcKFAVGps4PH6ec5vKatC",
  "redirect_uri": "http://localhost:9876/callback",
  "response_mode": "query",
  "response_type": "code",
  "scope": "openid email offline_access",
  "state": "hriVFbRRB4N5rFr2BrK9hh"
}

Signing key
none

Encryption key
-----BEGIN RSA PUBLIC KEY-----
MIIBCgKCAQEAu3igaELjc52QbjS1kr2LZ/jkrJheb7QN/Y1b/CNwvdNP/rGEHgT3
GHkfgd1l2C/Bl6CzZj+2ta2YE7Fn/+u0zHAfAtrUvhrl9QpcO9iDIDsjMkMDAUq8
v02nwhcfctwKZiWCPFtZPm7v8p8yUdnlMwPsfoIz4E15b0vRl2zURuoGWthZBLH4
Bq/h+gE8TVR0PGPzcVj/xKtZRc9iBv/4sN1FB+eST7kiaPNnmc9R8NLjEAKxyQRz
bt19NG8Wv0E/yjRluVD/CgvBwKOax95B2fdVaRNO/F02WfQb9VpIMp8FDSDo+qdn
F93OYdrc9vMtDxGXWOzDMkTFR/Rhv9MYtQIDAQAB
-----END RSA PUBLIC KEY-----


GET https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize
Query params:
  client_id: cauktionbud6q8ftlqq0
  request: eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwidHlwIjoiSldUIn0.TXVpUrYIossT2vbBTYG6aHAor1Po_zX7fZXpc7VpE54lIEKfaFk25lxs0X48wMenxzJQtqJHKViVSkytNTK1WC6hUJ5LmcN0HPC-S_jjjw20dky17HFK-0nghwU1qtOQ_9MVBdOZ2A_olA9uAL_o5yCVAnv1IgFq_7t-AH_hYLZalCCiTxGI40qtDJ938C7tjFAgRABJ4oi9lrrLTYjAeQ2gsVES-Eqf1-mwc8qyzTJs4sR8fDgGkOE_h1cQNWt-LjNxqDiKcFHYcPQ_8b1ikFqk0UvR1O2_K0RBKXlpryEFYJqSGtju776ZpBHW70MSKpRENIDZsc77YWMyZDUyvQ.Qc4s5eR5I2F0iDOw.BhyLawXy5JICzmVIQ-1EeqAtWaFZ9QkwkMOwWBqN6TUIV4xYxEioZcyjzhJimGklrkZQuoQldo6waWCB6NckBGCCBV_AABXwNCtzCsNYVxAL9hV8U47Ghq5LmdZOB2XNYyIxyGB8z_KVGlHNmUJ53wq6icQQteTEd4pYTwjRDxxBi_6NHmGgN4KibLWsorJXBBkhDoiKRdAlm46y0MQE_PMgNLLFN5IpOsZhLT5cH8bCW0_9YTcwpjifW_z3PZqxDZKUHrF2DhkD4sBu5renwluCbJSM4VduUEJatGUmAk6_Uh_uQF388GrcoCjOghzAu977NwwPYoU-h0li5cuZWdSWCjSv2_tHXiQquOCuCmCWBbosqvUsJBUByvDJvnT6uo6nBCGl36tzvsJfrF39GYeSg2tpHSPJAHOXp1i7HuXwSYVtlo6H4KBuRT2UR35mD3EgHV5iNLjP0cnuphTWycAoaE4AeadMravb6oRkyYhYKegMhc6_-taYwWRd233K2QjihnYdpvc5IQOb8OKz8AdVI5KUlwqBchZIcoAvdS_6FtFD_vTW4v6zsdLxHv9ZbtB3rZlVWfVbVL7Q5m5phzmBRcrHzUtQbK_9v11DHxCV1jYJAMQW.IbePQS3csqa51pWLlbGWMA
  scope: openid email offline_access

Open the following URL:

https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize?client_id=cauktionbud6q8ftlqq0&request=eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwidHlwIjoiSldUIn0.TXVpUrYIossT2vbBTYG6aHAor1Po_zX7fZXpc7VpE54lIEKfaFk25lxs0X48wMenxzJQtqJHKViVSkytNTK1WC6hUJ5LmcN0HPC-S_jjjw20dky17HFK-0nghwU1qtOQ_9MVBdOZ2A_olA9uAL_o5yCVAnv1IgFq_7t-AH_hYLZalCCiTxGI40qtDJ938C7tjFAgRABJ4oi9lrrLTYjAeQ2gsVES-Eqf1-mwc8qyzTJs4sR8fDgGkOE_h1cQNWt-LjNxqDiKcFHYcPQ_8b1ikFqk0UvR1O2_K0RBKXlpryEFYJqSGtju776ZpBHW70MSKpRENIDZsc77YWMyZDUyvQ.Qc4s5eR5I2F0iDOw.BhyLawXy5JICzmVIQ-1EeqAtWaFZ9QkwkMOwWBqN6TUIV4xYxEioZcyjzhJimGklrkZQuoQldo6waWCB6NckBGCCBV_AABXwNCtzCsNYVxAL9hV8U47Ghq5LmdZOB2XNYyIxyGB8z_KVGlHNmUJ53wq6icQQteTEd4pYTwjRDxxBi_6NHmGgN4KibLWsorJXBBkhDoiKRdAlm46y0MQE_PMgNLLFN5IpOsZhLT5cH8bCW0_9YTcwpjifW_z3PZqxDZKUHrF2DhkD4sBu5renwluCbJSM4VduUEJatGUmAk6_Uh_uQF388GrcoCjOghzAu977NwwPYoU-h0li5cuZWdSWCjSv2_tHXiQquOCuCmCWBbosqvUsJBUByvDJvnT6uo6nBCGl36tzvsJfrF39GYeSg2tpHSPJAHOXp1i7HuXwSYVtlo6H4KBuRT2UR35mD3EgHV5iNLjP0cnuphTWycAoaE4AeadMravb6oRkyYhYKegMhc6_-taYwWRd233K2QjihnYdpvc5IQOb8OKz8AdVI5KUlwqBchZIcoAvdS_6FtFD_vTW4v6zsdLxHv9ZbtB3rZlVWfVbVL7Q5m5phzmBRcrHzUtQbK_9v11DHxCV1jYJAMQW.IbePQS3csqa51pWLlbGWMA&scope=openid+email+offline_access


GET /callback
Query params:
  code: dHF_ZIGM7_KFtkXV4PFdQ1PqCRhk-HPlXl6a4eQaAcY.M38-D2YknEygAk5b97r8gY7jKmxVWCXWEcTilsEpNzY
  scope: openid email offline_access
  state: hriVFbRRB4N5rFr2BrK9hh

 SUCCESS  Obtained authorization code

# Exchange authorization code for token

┌─ Client Secret Basic ──────────────────────────────────────┐
| Authorization = Basic BASE64-ENCODE(ClientID:ClientSecret) |
└────────────────────────────────────────────────────────────┘

POST https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token
Headers:
  Authorization: Basic Y2F1a3Rpb25idWQ2cThmdGxxcTA6SEN3UTV1dVVXQlJIZDA0aXZqWDVLbDBSejh6eE1PZWtlTHRxemtpMEdQYw==
  Content-Type: application/x-www-form-urlencoded
Form post:
  grant_type: authorization_code
  redirect_uri: http://localhost:9876/callback
  code: dHF_ZIGM7_KFtkXV4PFdQ1PqCRhk-HPlXl6a4eQaAcY.M38-D2YknEygAk5b97r8gY7jKmxVWCXWEcTilsEpNzY
Response:
{
  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE4NzcyMjIzMzEzNjQwMTY2MDc5ODUxMjAwNDQwNTgwMzg2NDk3NiIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIxIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiXSwiYXVkIjpbImNhdWt0aW9uYnVkNnE4ZnRscXEwIiwic3BpZmZlOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8vZGVtby1wcm9maWxlIl0sImVtYWlsIjoiamRvZUBleGFtcGxlLmNvbSIsImV4cCI6MTY3MTcwOTgzNCwiaWF0IjoxNjcxNzA2MjMzLCJpZHAiOiJzYW5kYm94IiwiaXNzIjoiaHR0cHM6Ly9vYXV0aDJjLnVzLmF1dGh6LmNsb3VkZW50aXR5LmlvL29hdXRoMmMvZGVtbyIsImp0aSI6IjVlMjA1NjU3LTI1ZGQtNDRlYS1hNGJkLWEzY2MyZWM0MDczYyIsIm5iZiI6MTY3MTcwNjIzMywic2NwIjpbIm9wZW5pZCIsImVtYWlsIiwib2ZmbGluZV9hY2Nlc3MiXSwic3QiOiJwdWJsaWMiLCJzdWIiOiIxMWYxZWIzNmUyNDk2NjQ0OTMwMmNjZGVjYjM5NTBiMmQxMzIwNmYwYmQ0NmFhZWE3MDNmYmM4NjY2OWRkMDczIiwidGlkIjoib2F1dGgyYyJ9.AbJ6kycf-LWEnuRA5OoSUg_uRO5CCIfZwOwWQlyW1NFzA8ILII3MULGXQ8sKqO2kpLYdxTNvIxfACYHH9YJ1cgIC-HU07JtbADrNju49iG2NrPLgQd6UCrveD7xRraldWvaDjIQbv8FKDTvCLb0Cb7GwLKaAkRS7DMNiZgc8iXubI6wx6RpgF7GSG4jDMuQi0f_f3P-CjNbBNiijhqXfEcVStLl9WYPSlWM9itm6eNfN5dy4OvZe1xyAOvN2zB2N3xhWXzQOXNkBi-rzbHgR637JicefAtL5yNDgyErWRxvz40e4LaP95-u7exXv7PEHGT0A1SqdkawWjAXFKiYyJg",
  "expires_in": 3600,
  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE4NzcyMjIzMzEzNjQwMTY2MDc5ODUxMjAwNDQwNTgwMzg2NDk3NiIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhdF9oYXNoIjoiZmFwV05mM01VZnBycHdaYTBwRkZTQSIsImF1ZCI6ImNhdWt0aW9uYnVkNnE4ZnRscXEwIiwiYXV0aF90aW1lIjoxNjcwNzY1MDk3LCJleHAiOjE2NzE3MDk4MzMsImlhdCI6MTY3MTcwNjIzMywiaWRwIjoic2FuZGJveCIsImlkcG0iOiJzdGF0aWMiLCJpc3MiOiJodHRwczovL29hdXRoMmMudXMuYXV0aHouY2xvdWRlbnRpdHkuaW8vb2F1dGgyYy9kZW1vIiwianRpIjoiNzU0NGI3YmYtMTI3My00MmEwLWJmODAtMWIwYzE2NTEzMjFkIiwibm9uY2UiOiJjTWNLRkFWR3BzNFBINmVjNXZLYXRDIiwicmF0IjoxNjcxNzA2MjMzLCJyZWZyZXNoX3Rva2VuX2V4cGlyZXNfYXQiOjE2NzQyOTgyMzQsInN1YiI6IjExZjFlYjM2ZTI0OTY2NDQ5MzAyY2NkZWNiMzk1MGIyZDEzMjA2ZjBiZDQ2YWFlYTcwM2ZiYzg2NjY5ZGQwNzMifQ.UyB07IP5skus4SRmV_-KwHpJqu4g1-NQNezeUxh74dzOiPNB1RXj2LXVU3ugWVoPIxhKC-nVyUoawHAdoCEp-jPyYrBaR2aTMQZrKPb_RqD4G59Ke-b50inLotGfN9F32AZibUhYXafrjqA3EXPaCkZid3e8irQEVp1Bu-AM4YBJ4Pc63SB4DeI0g7WhIv_JFaoUySo6oJiSAzeGjRKxOnTSbCEpsUeWpaPPJuxTFg-tQt6vww03gc8y-KeAm3ZV_DmZsX9PXTQXouxJ7l5V0zDvxGe-BJ3SvK_0BFE9xrMH0dDpSTFtcoT84O90mQuJ8QrD5qfkfVSseF7lofp4CQ",
  "refresh_token": "IeKM4xmvcHjdC1PDzBsCXP1Zu73o7a1OAzWNGuXXiyw.y0RZLRM7N-3cCYTNL6OQh4Zv8i6qFdKLMOsV9UWeEn0",
  "scope": "openid email offline_access",
  "token_type": "bearer"
}
Access token:
{
  "acr": "1",
  "aid": "demo",
  "amr": ["pwd"],
  "aud": [
    "cauktionbud6q8ftlqq0",
    "spiffe://oauth2c.us.authz.cloudentity.io/oauth2c/demo/demo-profile"
  ],
  "email": "jdoe@example.com",
  "exp": 1671709834,
  "iat": 1671706233,
  "idp": "sandbox",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "5e205657-25dd-44ea-a4bd-a3cc2ec4073c",
  "nbf": 1671706233,
  "scp": ["openid", "email", "offline_access"],
  "st": "public",
  "sub": "11f1eb36e24966449302ccdecb3950b2d13206f0bd46aaea703fbc86669dd073",
  "tid": "oauth2c"
}
ID token:
{
  "acr": "1",
  "amr": ["pwd"],
  "at_hash": "fapWNf3MUfprpwZa0pFFSA",
  "aud": "cauktionbud6q8ftlqq0",
  "auth_time": 1670765097,
  "exp": 1671709833,
  "iat": 1671706233,
  "idp": "sandbox",
  "idpm": "static",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "7544b7bf-1273-42a0-bf80-1b0c1651321d",
  "nonce": "cMcKFAVGps4PH6ec5vKatC",
  "rat": 1671706233,
  "refresh_token_expires_at": 1674298234,
  "sub": "11f1eb36e24966449302ccdecb3950b2d13206f0bd46aaea703fbc86669dd073"
}

 SUCCESS  Exchanged authorization code for access token
➜  oauth2c git:(feature/encrypted-request-object)
```