### PR TITLE
Always use mtls token endpoint if certificate is configured

### DIFF
--- a/internal/oauth2/request.go
+++ b/internal/oauth2/request.go
@@ -164,12 +164,12 @@ func (r *Request) AuthenticateClient(
 		r.Form.Set("client_assertion", clientAssertion)
 	case TLSClientAuthMethod, SelfSignedTLSAuthMethod:
 		r.Form.Set("client_id", cconfig.ClientID)
-		endpoint = mtlsEndpoint
+	}
 
-		if tr, ok := hc.Transport.(*http.Transport); ok {
-			if len(tr.TLSClientConfig.Certificates) > 0 {
-				r.Cert, _ = x509.ParseCertificate(tr.TLSClientConfig.Certificates[0].Certificate[0])
-			}
+	if tr, ok := hc.Transport.(*http.Transport); ok {
+		if len(tr.TLSClientConfig.Certificates) > 0 {
+			r.Cert, _ = x509.ParseCertificate(tr.TLSClientConfig.Certificates[0].Certificate[0])
+			endpoint = mtlsEndpoint
 		}
 	}
 


### PR DESCRIPTION
Certificate bound access token can be issued not only for tls token authn method but also for private_key_jwt.
In this PR mtls token endpoint will always used if certificate is configured regardless of token authn method.