### PR TITLE
handle empty redirect URL

### DIFF
--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -209,6 +209,9 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 	}
 
 	srv.Addr = redirectURL.Host
+	if redirectURL.Path == "" {
+		redirectURL.Path = "/"
+	}
 
 	http.HandleFunc(redirectURL.Path, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {


### PR DESCRIPTION
Specifying a redirect URL without any additional path behind the hostname/port (e.g. `--redirect-url=http://localhost:3000`) panics the program with `panic: http: invalid pattern`, as `http.HandleFunc` doesn't want an empty string as a handler.