### PR TITLE
RAR add authorization_details to the /token response

### DIFF
--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -282,13 +282,14 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 }
 
 type TokenResponse struct {
-	AccessToken     string `json:"access_token,omitempty"`
-	ExpiresIn       int64  `json:"expires_in,omitempty"`
-	IDToken         string `json:"id_token,omitempty"`
-	IssuedTokenType string `json:"issued_token_type,omitempty"`
-	RefreshToken    string `json:"refresh_token,omitempty"`
-	Scope           string `json:"scope,omitempty"`
-	TokenType       string `json:"token_type,omitempty"`
+	AccessToken          string                   `json:"access_token,omitempty"`
+	ExpiresIn            int64                    `json:"expires_in,omitempty"`
+	IDToken              string                   `json:"id_token,omitempty"`
+	IssuedTokenType      string                   `json:"issued_token_type,omitempty"`
+	RefreshToken         string                   `json:"refresh_token,omitempty"`
+	Scope                string                   `json:"scope,omitempty"`
+	TokenType            string                   `json:"token_type,omitempty"`
+	AuthorizationDetails []map[string]interface{} `json:"authorization_details,omitempty"`
 }
 
 func NewTokenResponseFromForm(f url.Values) TokenResponse {


### PR DESCRIPTION
- add `authorization_details` to the /token response as defined in: https://datatracker.ietf.org/doc/html/rfc9396#name-token-response