### PR TITLE
Parse signing key and encryption key only if JARM response is present

### DIFF
--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -224,8 +224,10 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 		request.Form = r.PostForm
 
 		if request.Get("response") != "" {
-			signingKey := jose.JSONWebKey{}
-			encryptionKey := jose.JSONWebKey{}
+			var (
+				signingKey    jose.JSONWebKey
+				encryptionKey jose.JSONWebKey
+			)
 
 			if signingKey, err = ReadKey(SigningKey, serverConfig.JWKsURI, hc); err != nil {
 				log.Fatal(err)

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -190,28 +190,17 @@ func RequestPAR(
 
 func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *http.Client) (request Request, err error) {
 	var (
-		srv           = http.Server{}
-		redirectURL   *url.URL
-		signingKey    jose.JSONWebKey
-		encryptionKey jose.JSONWebKey
-		done          = make(chan struct{})
+		srv         = http.Server{}
+		redirectURL *url.URL
+		done        = make(chan struct{})
 	)
 
 	if redirectURL, err = url.Parse(clientConfig.RedirectURL); err != nil {
 		return request, errors.Wrapf(err, "failed to parse redirect url: %s", clientConfig.RedirectURL)
 	}
 
-	if signingKey, err = ReadKey(SigningKey, serverConfig.JWKsURI, hc); err != nil {
-		return request, errors.Wrapf(err, "failed to read signing key from %s", serverConfig.JWKsURI)
-	}
-
-	if clientConfig.EncryptionKey != "" {
-		if encryptionKey, err = ReadKey(EncryptionKey, clientConfig.EncryptionKey, hc); err != nil {
-			return request, errors.Wrapf(err, "failed to read encryption key from %s", clientConfig.EncryptionKey)
-		}
-	}
-
 	srv.Addr = redirectURL.Host
+
 	if redirectURL.Path == "" {
 		redirectURL.Path = "/"
 	}
@@ -234,9 +223,26 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 		request.URL = r.URL
 		request.Form = r.PostForm
 
-		if err = request.ParseJARM(signingKey, encryptionKey); err != nil {
-			log.Fatal(err)
-			return
+		if request.Get("response") != "" {
+			signingKey := jose.JSONWebKey{}
+			encryptionKey := jose.JSONWebKey{}
+
+			if signingKey, err = ReadKey(SigningKey, serverConfig.JWKsURI, hc); err != nil {
+				log.Fatal(err)
+				return
+			}
+
+			if clientConfig.EncryptionKey != "" {
+				if encryptionKey, err = ReadKey(EncryptionKey, clientConfig.EncryptionKey, hc); err != nil {
+					log.Fatal(err)
+					return
+				}
+			}
+
+			if err = request.ParseJARM(signingKey, encryptionKey); err != nil {
+				log.Fatal(err)
+				return
+			}
 		}
 
 		w.Header().Add("Content-Type", "text/html")

--- a/internal/oauth2/request.go
+++ b/internal/oauth2/request.go
@@ -215,26 +215,24 @@ func (r *Request) ParseJARM(signingKey interface{}, encryptionKey interface{}) e
 
 	r.JARM = map[string]interface{}{}
 
-	if response != "" {
-		if nestedToken, err = jwt.ParseSignedAndEncrypted(response); err != nil {
-			if token, err2 = jwt.ParseSigned(response); err2 != nil {
-				return errors.Wrapf(multierror.Append(err, err2), "failed to parse JARM response")
-			}
-		} else if encryptionKey != nil {
-			if token, err = nestedToken.Decrypt(encryptionKey); err != nil {
-				return errors.Wrapf(err, "failed to decrypt encrypted JARM response")
-			}
-		} else {
-			return errors.New("no encryption key path")
+	if nestedToken, err = jwt.ParseSignedAndEncrypted(response); err != nil {
+		if token, err2 = jwt.ParseSigned(response); err2 != nil {
+			return errors.Wrapf(multierror.Append(err, err2), "failed to parse JARM response")
 		}
+	} else if encryptionKey != nil {
+		if token, err = nestedToken.Decrypt(encryptionKey); err != nil {
+			return errors.Wrapf(err, "failed to decrypt encrypted JARM response")
+		}
+	} else {
+		return errors.New("no encryption key path")
+	}
 
-		if signingKey == nil {
-			return errors.New("no signing key path")
-		}
+	if signingKey == nil {
+		return errors.New("no signing key path")
+	}
 
-		if err = token.Claims(signingKey, &r.JARM); err != nil {
-			return err
-		}
+	if err = token.Claims(signingKey, &r.JARM); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
There is no need to read public signing and encryption keys from JWKs endpoint if the JARM response is not present.

This is a workaround for #70 