### PR TITLE
Print debug info to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The available flags are:
       --idp-hint string             identity provider hint
       --insecure                    allow insecure connections
       --login-hint string           user identifier hint
+      --no-prompt                   disable prompt
       --par                         enable pushed authorization requests (PAR)
       --password string             resource owner password credentials grant flow password
       --pkce                        enable proof key for code exchange (PKCE)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"os"
 	"strconv"
 	"strings"
 
@@ -18,6 +19,10 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/tidwall/pretty"
 )
+
+func init() {
+	pterm.SetDefaultOutput(os.Stderr)
+}
 
 func Logln() {
 	if silent {
@@ -59,6 +64,7 @@ func LogAction(msg string) func(string) {
 	done, _ := pterm.DefaultSpinner.Start(msg)
 	return func(s string) {
 		done.Success(s)
+		pterm.Println()
 	}
 }
 

--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -19,7 +19,8 @@ import (
 )
 
 var (
-	silent bool
+	silent   bool
+	noPrompt bool
 )
 
 type OAuth2Cmd struct {
@@ -74,6 +75,7 @@ func NewOAuth2Cmd() (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().DurationVar(&cconfig.Timeout, "timeout", time.Minute, "http client timeout")
 	cmd.PersistentFlags().BoolVar(&cconfig.Insecure, "insecure", false, "allow insecure connections")
 	cmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "silent mode")
+	cmd.PersistentFlags().BoolVar(&noPrompt, "no-prompt", false, "disable prompt")
 	cmd.PersistentFlags().BoolVar(&cconfig.DPoP, "dpop", false, "use DPoP")
 	cmd.PersistentFlags().StringVar(&cconfig.Claims, "claims", "", "use claims")
 	cmd.PersistentFlags().StringVar(&cconfig.RAR, "rar", "", "use rich authorization request (RAR)")
@@ -107,6 +109,8 @@ func (c *OAuth2Cmd) Run(cconfig *oauth2.ClientConfig) func(cmd *cobra.Command, a
 
 		if silent {
 			browser.Stdout = io.Discard
+		} else {
+			browser.Stdout = os.Stderr
 		}
 
 		tr := &http.Transport{
@@ -168,7 +172,7 @@ func (c *OAuth2Cmd) Authorize(clientConfig oauth2.ClientConfig, hc *http.Client)
 		return err
 	}
 
-	if !silent {
+	if !silent && !noPrompt {
 		clientConfig = PromptForClientConfig(clientConfig, serverConfig)
 	}
 
@@ -197,10 +201,6 @@ func (c *OAuth2Cmd) Authorize(clientConfig oauth2.ClientConfig, hc *http.Client)
 }
 
 func (c *OAuth2Cmd) PrintResult(result interface{}) {
-	if !silent {
-		return
-	}
-
 	output, err := json.Marshal(result)
 
 	if err != nil {

--- a/cmd/oauth2_authorize_code.go
+++ b/cmd/oauth2_authorize_code.go
@@ -98,9 +98,9 @@ func (c *OAuth2Cmd) AuthorizationCodeGrantFlow(clientConfig oauth2.ClientConfig,
 	LogRequestAndResponse(tokenRequest, tokenResponse)
 	LogTokenPayloadln(tokenResponse)
 
-	c.PrintResult(tokenResponse)
-
 	exchangeStatus("Exchanged authorization code for access token")
+
+	c.PrintResult(tokenResponse)
 
 	return nil
 }

--- a/cmd/oauth2_device.go
+++ b/cmd/oauth2_device.go
@@ -92,9 +92,9 @@ func (c *OAuth2Cmd) DeviceGrantFlow(clientConfig oauth2.ClientConfig, serverConf
 	LogRequestAndResponse(tokenRequest, tokenResponse)
 	LogTokenPayloadln(tokenResponse)
 
-	c.PrintResult(tokenResponse)
-
 	tokenStatus("Obtained token")
+
+	c.PrintResult(tokenResponse)
 
 	return nil
 }

--- a/cmd/oauth2_implicit.go
+++ b/cmd/oauth2_implicit.go
@@ -47,9 +47,9 @@ func (c *OAuth2Cmd) ImplicitGrantFlow(clientConfig oauth2.ClientConfig, serverCo
 	LogTokenPayloadln(tokenResponse)
 	Logln()
 
-	c.PrintResult(tokenResponse)
-
 	callbackStatus("Obtained authorization")
+
+	c.PrintResult(tokenResponse)
 
 	return nil
 }

--- a/cmd/oauth2_token.go
+++ b/cmd/oauth2_token.go
@@ -66,9 +66,9 @@ func (c *OAuth2Cmd) tokenEndpointFlow(
 	LogRequestAndResponse(tokenRequest, tokenResponse)
 	LogTokenPayloadln(tokenResponse)
 
-	c.PrintResult(tokenResponse)
-
 	authorizationStatus("Authorization completed")
+
+	c.PrintResult(tokenResponse)
 
 	return nil
 }


### PR DESCRIPTION
Print all debug info to stderr and always print the result as raw json to stdout 

Solves #76 

``` sh
oauth2c on  feature/stderr [$] via 🐹 v1.21.0
❯ go run . https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
  --client-id cauktionbud6q8ftlqq0 \
  --client-secret HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc \
  --response-types code \
  --response-mode query \
  --grant-type authorization_code \
  --auth-method client_secret_basic \
  --scopes openid,email,offline_access > stdout 2> stderr

oauth2c on  feature/stderr [$?] via 🐹 v1.21.0 took 3s
❯ cat stdout
{"access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3NDYyMTE3MzM2Mjc1NzU0MzM1MzIzOTQwMjgzMjA1Mjk2MzM5NyIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIwIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXVkIjpbImNhdWt0aW9uYnVkNnE4ZnRscXEwIiwic3BpZmZlOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8vZGVtby1wcm9maWxlIl0sImVtYWlsIjoibWF0ZXVzei5iaWxza2lAZ21haWwuY29tIiwiZXhwIjoxNjk1OTk1ODI4LCJpYXQiOjE2OTU5OTIyMjgsImlkcCI6ImdpdGh1Yl9lbWJlZGRlZCIsImlzcyI6Imh0dHBzOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8iLCJqdGkiOiI2NDZkOTIwZi1kZDMyLTQyYWYtOGJiMC0xZjJmOTRlNmZiYjAiLCJuYmYiOjE2OTU5OTIyMjgsInNjcCI6WyJlbWFpbCIsIm9mZmxpbmVfYWNjZXNzIiwib3BlbmlkIl0sInN0IjoicHVibGljIiwic3ViIjoiMGZmM2Y4N2NlNzE5YWQyMmFmZjNjMDQwN2EyNWM4N2MzZDhjMmZlN2Y3NDhlYWQ3OTkwZjI2ZDM3NzE4YTg1NiIsInRpZCI6Im9hdXRoMmMifQ.SrPvQw2Ha5o5Azw_Ex_9opBvpjN6Hib3CILl87GG547RRvVMauU7KEyuNBKAsz4TpN0MyZq_SUZbtFq0q9TzzXSqRPXDDlkzz0M7KeKT0gKL7jc9KCZXXQ9Vh-yBPwxe1GT1ZVCUO02d_Ebr76JW2fO9SkTgvEc2864zCVdh0UxMH8zkmBzB9A-MFgVcvggEmqphr8-ZjSeMUIWIPggKs82oimeM7y5eaAy8zTugCPFcZOZEV3VLFAQT6l4Ke8EHrDCcGu0YyfT0XldX0K40pLaWtNY2Zy42C8T_lEM8UKoCPSL7jVXfaZ6-GAEvmpR3soHrniOWDhU84BUjxu2cdA","expires_in":3599,"id_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3NDYyMTE3MzM2Mjc1NzU0MzM1MzIzOTQwMjgzMjA1Mjk2MzM5NyIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIwIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXRfaGFzaCI6IllPdVVmaDA4dzRLeWpZWVpiMVZvSHciLCJhdWQiOiJjYXVrdGlvbmJ1ZDZxOGZ0bHFxMCIsImF1dGhfdGltZSI6MTY5NTk5MjEyMiwiZXhwIjoxNjk1OTk1ODI4LCJpYXQiOjE2OTU5OTIyMjgsImlkcCI6ImdpdGh1Yl9lbWJlZGRlZCIsImlkcG0iOiJzdGF0aWMiLCJpc3MiOiJodHRwczovL29hdXRoMmMudXMuYXV0aHouY2xvdWRlbnRpdHkuaW8vb2F1dGgyYy9kZW1vIiwianRpIjoiYTIyZDVmN2ItNzc3Mi00YTZlLWE5NWItMTUzMDAyNjA3NDhkIiwibm9uY2UiOiJuZ2RIS3R6VGlVckdxVlk0U2drYWljIiwic3ViIjoiMGZmM2Y4N2NlNzE5YWQyMmFmZjNjMDQwN2EyNWM4N2MzZDhjMmZlN2Y3NDhlYWQ3OTkwZjI2ZDM3NzE4YTg1NiIsInRpZCI6Im9hdXRoMmMifQ.d4-hxLfVOx-lvWkGHcKnbHw236_t4AAsO50Da7xAWCzOjbw4FMAxZJ5AU3mWdXsob-0_JU88NRvahAgTkdx96oVmBi7KAoPpnn_1kamUhsCxJzaGcXUZSz4jNWV7idOZS3xtCNLD398AL_PhtMpUnl1qEeQJej6QxN4I396baLBqQ-xQVw_okytMnGCbqyuwEqyP7iChmaY5pLO2bsfbpVEZtbQ5pCinKX8_cwTfvYsyZsPYEQFcjQxIZsOKu8NcJ3V2HrX_e-hXvjIk6X5sHi8iqB7SAnzsnawJJLPwZdjmEeMald20rsKCsdP9NQasWpOZSqRxlkpgo0X-HywnDg","refresh_token":"qu7J2SnfJdv1shdIFIcKVlBv2H8qlp8KIy9C3QCXzpE.aqKCTKsx2jo0M5F0Sv5ArK9k4GFzQ2zd-Yc14Oix-nA","scope":"email offline_access openid","token_type":"bearer"}

oauth2c on  feature/stderr [$?] via 🐹 v1.21.0
❯ cat stderr
┌───────────────────────────────────────────────────────────────────────┐
| Issuer URL     | https://oauth2c.us.authz.cloudentity.io/oauth2c/demo |
| Grant type     | authorization_code                                   |
| Auth method    | client_secret_basic                                  |
| Scopes         | openid, email, offline_access                        |
| Response types | code                                                 |
| Response mode  | query                                                |
| PKCE           | false                                                |
| Client ID      | cauktionbud6q8ftlqq0                                 |
| Client secret  | HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc          |
└───────────────────────────────────────────────────────────────────────┘


                            Authorization Code Flow


# Request authorization

GET https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize
Query params:
  scope: openid email offline_access
  state: oKbYHnxNgmCbuooYurGe7S
  client_id: cauktionbud6q8ftlqq0
  nonce: ngdHKtzTiUrGqVY4Sgkaic
  redirect_uri: http://localhost:9876/callback
  response_mode: query
  response_type: code

Open the following URL:

https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize?client_id=cauktionbud6q8ftlqq0&nonce=ngdHKtzTiUrGqVY4Sgkaic&redirect_uri=http%3A%2F%2Flocalhost%3A9876%2Fcallback&response_mode=query&response_type=code&scope=openid+email+offline_access&state=oKbYHnxNgmCbuooYurGe7S


GET /callback
Query params:
  code: mw4gr4BveOuO_hoOhfm9ZmuYC-tzs4Q3LAndGtMlMHQ.vjelJQRfg7rblL4Mql0MDQEzYI-TmnGBmoaUA3I_T9s
  state: oKbYHnxNgmCbuooYurGe7S

 SUCCESS  Obtained authorization code


# Exchange authorization code for token

┌─ Client Secret Basic ──────────────────────────────────────┐
| Authorization = Basic BASE64-ENCODE(ClientID:ClientSecret) |
└────────────────────────────────────────────────────────────┘

POST https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token
Headers:
  Authorization: Basic Y2F1a3Rpb25idWQ2cThmdGxxcTA6SEN3UTV1dVVXQlJIZDA0aXZqWDVLbDBSejh6eE1PZWtlTHRxemtpMEdQYw==
  Content-Type: application/x-www-form-urlencoded
Form post:
  code: mw4gr4BveOuO_hoOhfm9ZmuYC-tzs4Q3LAndGtMlMHQ.vjelJQRfg7rblL4Mql0MDQEzYI-TmnGBmoaUA3I_T9s
  grant_type: authorization_code
  redirect_uri: http://localhost:9876/callback
Response:
{
  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3NDYyMTE3MzM2Mjc1NzU0MzM1MzIzOTQwMjgzMjA1Mjk2MzM5NyIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIwIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXVkIjpbImNhdWt0aW9uYnVkNnE4ZnRscXEwIiwic3BpZmZlOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8vZGVtby1wcm9maWxlIl0sImVtYWlsIjoibWF0ZXVzei5iaWxza2lAZ21haWwuY29tIiwiZXhwIjoxNjk1OTk1ODI4LCJpYXQiOjE2OTU5OTIyMjgsImlkcCI6ImdpdGh1Yl9lbWJlZGRlZCIsImlzcyI6Imh0dHBzOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8iLCJqdGkiOiI2NDZkOTIwZi1kZDMyLTQyYWYtOGJiMC0xZjJmOTRlNmZiYjAiLCJuYmYiOjE2OTU5OTIyMjgsInNjcCI6WyJlbWFpbCIsIm9mZmxpbmVfYWNjZXNzIiwib3BlbmlkIl0sInN0IjoicHVibGljIiwic3ViIjoiMGZmM2Y4N2NlNzE5YWQyMmFmZjNjMDQwN2EyNWM4N2MzZDhjMmZlN2Y3NDhlYWQ3OTkwZjI2ZDM3NzE4YTg1NiIsInRpZCI6Im9hdXRoMmMifQ.SrPvQw2Ha5o5Azw_Ex_9opBvpjN6Hib3CILl87GG547RRvVMauU7KEyuNBKAsz4TpN0MyZq_SUZbtFq0q9TzzXSqRPXDDlkzz0M7KeKT0gKL7jc9KCZXXQ9Vh-yBPwxe1GT1ZVCUO02d_Ebr76JW2fO9SkTgvEc2864zCVdh0UxMH8zkmBzB9A-MFgVcvggEmqphr8-ZjSeMUIWIPggKs82oimeM7y5eaAy8zTugCPFcZOZEV3VLFAQT6l4Ke8EHrDCcGu0YyfT0XldX0K40pLaWtNY2Zy42C8T_lEM8UKoCPSL7jVXfaZ6-GAEvmpR3soHrniOWDhU84BUjxu2cdA",
  "expires_in": 3599,
  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3NDYyMTE3MzM2Mjc1NzU0MzM1MzIzOTQwMjgzMjA1Mjk2MzM5NyIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIwIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXRfaGFzaCI6IllPdVVmaDA4dzRLeWpZWVpiMVZvSHciLCJhdWQiOiJjYXVrdGlvbmJ1ZDZxOGZ0bHFxMCIsImF1dGhfdGltZSI6MTY5NTk5MjEyMiwiZXhwIjoxNjk1OTk1ODI4LCJpYXQiOjE2OTU5OTIyMjgsImlkcCI6ImdpdGh1Yl9lbWJlZGRlZCIsImlkcG0iOiJzdGF0aWMiLCJpc3MiOiJodHRwczovL29hdXRoMmMudXMuYXV0aHouY2xvdWRlbnRpdHkuaW8vb2F1dGgyYy9kZW1vIiwianRpIjoiYTIyZDVmN2ItNzc3Mi00YTZlLWE5NWItMTUzMDAyNjA3NDhkIiwibm9uY2UiOiJuZ2RIS3R6VGlVckdxVlk0U2drYWljIiwic3ViIjoiMGZmM2Y4N2NlNzE5YWQyMmFmZjNjMDQwN2EyNWM4N2MzZDhjMmZlN2Y3NDhlYWQ3OTkwZjI2ZDM3NzE4YTg1NiIsInRpZCI6Im9hdXRoMmMifQ.d4-hxLfVOx-lvWkGHcKnbHw236_t4AAsO50Da7xAWCzOjbw4FMAxZJ5AU3mWdXsob-0_JU88NRvahAgTkdx96oVmBi7KAoPpnn_1kamUhsCxJzaGcXUZSz4jNWV7idOZS3xtCNLD398AL_PhtMpUnl1qEeQJej6QxN4I396baLBqQ-xQVw_okytMnGCbqyuwEqyP7iChmaY5pLO2bsfbpVEZtbQ5pCinKX8_cwTfvYsyZsPYEQFcjQxIZsOKu8NcJ3V2HrX_e-hXvjIk6X5sHi8iqB7SAnzsnawJJLPwZdjmEeMald20rsKCsdP9NQasWpOZSqRxlkpgo0X-HywnDg",
  "refresh_token": "qu7J2SnfJdv1shdIFIcKVlBv2H8qlp8KIy9C3QCXzpE.aqKCTKsx2jo0M5F0Sv5ArK9k4GFzQ2zd-Yc14Oix-nA",
  "scope": "email offline_access openid",
  "token_type": "bearer"
}
Access token:
{
  "acr": "0",
  "aid": "demo",
  "amr": ["pwd", "mfa"],
  "aud": [
    "cauktionbud6q8ftlqq0",
    "spiffe://oauth2c.us.authz.cloudentity.io/oauth2c/demo/demo-profile"
  ],
  "email": "mateusz.bilski@gmail.com",
  "exp": 1695995828,
  "iat": 1695992228,
  "idp": "github_embedded",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "646d920f-dd32-42af-8bb0-1f2f94e6fbb0",
  "nbf": 1695992228,
  "scp": ["email", "offline_access", "openid"],
  "st": "public",
  "sub": "0ff3f87ce719ad22aff3c0407a25c87c3d8c2fe7f748ead7990f26d37718a856",
  "tid": "oauth2c"
}
ID token:
{
  "acr": "0",
  "aid": "demo",
  "amr": ["pwd", "mfa"],
  "at_hash": "YOuUfh08w4KyjYYZb1VoHw",
  "aud": "cauktionbud6q8ftlqq0",
  "auth_time": 1695992122,
  "exp": 1695995828,
  "iat": 1695992228,
  "idp": "github_embedded",
  "idpm": "static",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "a22d5f7b-7772-4a6e-a95b-15300260748d",
  "nonce": "ngdHKtzTiUrGqVY4Sgkaic",
  "sub": "0ff3f87ce719ad22aff3c0407a25c87c3d8c2fe7f748ead7990f26d37718a856",
  "tid": "oauth2c"
}

 SUCCESS  Exchanged authorization code for access token
```

```sh
oauth2c on  feature/stderr [$?] via 🐹 v1.21.0
❯ export TOKEN=`go run . https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
  --client-id cauktionbud6q8ftlqq0 \
  --client-secret HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc \
  --response-types code \
  --response-mode query \
  --grant-type authorization_code \
  --auth-method client_secret_basic \
  --scopes openid,email,offline_access | jq -r .access_token`
┌───────────────────────────────────────────────────────────────────────┐
| Issuer URL     | https://oauth2c.us.authz.cloudentity.io/oauth2c/demo |
| Grant type     | authorization_code                                   |
| Auth method    | client_secret_basic                                  |
| Scopes         | openid, email, offline_access                        |
| Response types | code                                                 |
| Response mode  | query                                                |
| PKCE           | false                                                |
| Client ID      | cauktionbud6q8ftlqq0                                 |
| Client secret  | HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc          |
└───────────────────────────────────────────────────────────────────────┘


                            Authorization Code Flow


# Request authorization

GET https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize
Query params:
  client_id: cauktionbud6q8ftlqq0
  nonce: jeSQyXEaA5si6V85c54vPS
  redirect_uri: http://localhost:9876/callback
  response_mode: query
  response_type: code
  scope: openid email offline_access
  state: ddFiva6Cv96k8GiGmCi2yv

Open the following URL:

https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize?client_id=cauktionbud6q8ftlqq0&nonce=jeSQyXEaA5si6V85c54vPS&redirect_uri=http%3A%2F%2Flocalhost%3A9876%2Fcallback&response_mode=query&response_type=code&scope=openid+email+offline_access&state=ddFiva6Cv96k8GiGmCi2yv


GET /callback
Query params:
  code: ulRWh5K3bAt5hUv9iKHKEs9_AEffIpKwa1d22IZ_q6U.X4zV07MaLKshHCAtqWrxz7mtZqjdsN2mNPq8EgIlzNI
  state: ddFiva6Cv96k8GiGmCi2yv

 SUCCESS  Obtained authorization code


# Exchange authorization code for token

┌─ Client Secret Basic ──────────────────────────────────────┐
| Authorization = Basic BASE64-ENCODE(ClientID:ClientSecret) |
└────────────────────────────────────────────────────────────┘

POST https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token
Headers:
  Authorization: Basic Y2F1a3Rpb25idWQ2cThmdGxxcTA6SEN3UTV1dVVXQlJIZDA0aXZqWDVLbDBSejh6eE1PZWtlTHRxemtpMEdQYw==
  Content-Type: application/x-www-form-urlencoded
Form post:
  code: ulRWh5K3bAt5hUv9iKHKEs9_AEffIpKwa1d22IZ_q6U.X4zV07MaLKshHCAtqWrxz7mtZqjdsN2mNPq8EgIlzNI
  grant_type: authorization_code
  redirect_uri: http://localhost:9876/callback
Response:
{
  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3NDYyMTE3MzM2Mjc1NzU0MzM1MzIzOTQwMjgzMjA1Mjk2MzM5NyIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIwIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXVkIjpbImNhdWt0aW9uYnVkNnE4ZnRscXEwIiwic3BpZmZlOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8vZGVtby1wcm9maWxlIl0sImVtYWlsIjoibWF0ZXVzei5iaWxza2lAZ21haWwuY29tIiwiZXhwIjoxNjk1OTk1OTkxLCJpYXQiOjE2OTU5OTIzOTAsImlkcCI6ImdpdGh1Yl9lbWJlZGRlZCIsImlzcyI6Imh0dHBzOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8iLCJqdGkiOiJjODY4NDAxMS0xMTc3LTQ1NmYtYTc5My1lOTMyMmRmZGRlZWMiLCJuYmYiOjE2OTU5OTIzOTAsInNjcCI6WyJlbWFpbCIsIm9mZmxpbmVfYWNjZXNzIiwib3BlbmlkIl0sInN0IjoicHVibGljIiwic3ViIjoiMGZmM2Y4N2NlNzE5YWQyMmFmZjNjMDQwN2EyNWM4N2MzZDhjMmZlN2Y3NDhlYWQ3OTkwZjI2ZDM3NzE4YTg1NiIsInRpZCI6Im9hdXRoMmMifQ.tWHwunTLBIcoeeAW2EAaVvb1ekM_N_9zKVJzXQkHLXOGAJhroyVYjTCPNl0UOxdF84qBsq0Z8qJ4CtNeVQwDCv3tJ3zfTa_2g8RlaASgdn018ATXgutOJmzjmNHyn1USgh5GeUs7CojZBtYA-FrU1E4MidhHGfJDL1k1zsLjzTC-Nw1qnago5gSX6RBH6JYJSIZR-kbwGGR7ywOp6_DmJH6YzOAtUblxzUX45VU2SVJE0ESI1dkgWrE-U6YT3-iPVW5GBclxTthrIJMvyq2KjPoPxGuPyCdz0UGTT_bBiiNHbu1X_kuoR0ghCI5QGCQWm8pq2r8PrzDVlRjuslcwkw",
  "expires_in": 3600,
  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3NDYyMTE3MzM2Mjc1NzU0MzM1MzIzOTQwMjgzMjA1Mjk2MzM5NyIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIwIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXRfaGFzaCI6InZDZngwR2Ixa0R4UUIxU1haRWdpYmciLCJhdWQiOiJjYXVrdGlvbmJ1ZDZxOGZ0bHFxMCIsImF1dGhfdGltZSI6MTY5NTk5MjEyMiwiZXhwIjoxNjk1OTk1OTkwLCJpYXQiOjE2OTU5OTIzOTAsImlkcCI6ImdpdGh1Yl9lbWJlZGRlZCIsImlkcG0iOiJzdGF0aWMiLCJpc3MiOiJodHRwczovL29hdXRoMmMudXMuYXV0aHouY2xvdWRlbnRpdHkuaW8vb2F1dGgyYy9kZW1vIiwianRpIjoiNDA0ZGZkODAtNmI5NC00MzFkLTliOTEtYzE5YmMzNWEwOTY4Iiwibm9uY2UiOiJqZVNReVhFYUE1c2k2Vjg1YzU0dlBTIiwic3ViIjoiMGZmM2Y4N2NlNzE5YWQyMmFmZjNjMDQwN2EyNWM4N2MzZDhjMmZlN2Y3NDhlYWQ3OTkwZjI2ZDM3NzE4YTg1NiIsInRpZCI6Im9hdXRoMmMifQ.YWps8nGd1q9wC2uXKLFr9KQgfEMZvFswucFPKyzQetNdZzDhSBRgqS-VGVZ0i_P5YHcpBtLWNHyLVX-YJHpCmjhbpnxPUNNWCuHAyCq5SnzZb-3smwig6Dt8MfMsDShr90g5-azreCMr7XBS2eUTJNUOIyKDzgUQ0NGPWl6nuRlamCfnkGDh0Ikf8v6Ha3ElfNS6sUwQE6-Z6M8tztfquVQU4SNnUBBL1pvzV3w4gn4indjvhTwAyu6GaL2gazOBOxKVMuX136sbk8snUyKASoxKqCJNx--bbQzwqPKdEJv64DuTNIF0cjO2CQz7mrxs3f6HtUT-_xc2PDDm31OKWA",
  "refresh_token": "6FeAOx6RBhd5lhsxNbO6_iC5MUuQldfZ0jNA5UuQI1c.DQhadw64UXoRf3bnzctJLjLW8EO-MOaoU3ErNW2KZzc",
  "scope": "email offline_access openid",
  "token_type": "bearer"
}
Access token:
{
  "acr": "0",
  "aid": "demo",
  "amr": ["pwd", "mfa"],
  "aud": [
    "cauktionbud6q8ftlqq0",
    "spiffe://oauth2c.us.authz.cloudentity.io/oauth2c/demo/demo-profile"
  ],
  "email": "mateusz.bilski@gmail.com",
  "exp": 1695995991,
  "iat": 1695992390,
  "idp": "github_embedded",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "c8684011-1177-456f-a793-e9322dfddeec",
  "nbf": 1695992390,
  "scp": ["email", "offline_access", "openid"],
  "st": "public",
  "sub": "0ff3f87ce719ad22aff3c0407a25c87c3d8c2fe7f748ead7990f26d37718a856",
  "tid": "oauth2c"
}
ID token:
{
  "acr": "0",
  "aid": "demo",
  "amr": ["pwd", "mfa"],
  "at_hash": "vCfx0Gb1kDxQB1SXZEgibg",
  "aud": "cauktionbud6q8ftlqq0",
  "auth_time": 1695992122,
  "exp": 1695995990,
  "iat": 1695992390,
  "idp": "github_embedded",
  "idpm": "static",
  "iss": "https://oauth2c.us.authz.cloudentity.io/oauth2c/demo",
  "jti": "404dfd80-6b94-431d-9b91-c19bc35a0968",
  "nonce": "jeSQyXEaA5si6V85c54vPS",
  "sub": "0ff3f87ce719ad22aff3c0407a25c87c3d8c2fe7f748ead7990f26d37718a856",
  "tid": "oauth2c"
}

 SUCCESS  Exchanged authorization code for access token


oauth2c on  feature/stderr [$?] via 🐹 v1.21.0 took 2s
❯ echo $TOKEN
eyJhbGciOiJSUzI1NiIsImtpZCI6IjE3NDYyMTE3MzM2Mjc1NzU0MzM1MzIzOTQwMjgzMjA1Mjk2MzM5NyIsInR5cCI6IkpXVCJ9.eyJhY3IiOiIwIiwiYWlkIjoiZGVtbyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXVkIjpbImNhdWt0aW9uYnVkNnE4ZnRscXEwIiwic3BpZmZlOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8vZGVtby1wcm9maWxlIl0sImVtYWlsIjoibWF0ZXVzei5iaWxza2lAZ21haWwuY29tIiwiZXhwIjoxNjk1OTk1OTkxLCJpYXQiOjE2OTU5OTIzOTAsImlkcCI6ImdpdGh1Yl9lbWJlZGRlZCIsImlzcyI6Imh0dHBzOi8vb2F1dGgyYy51cy5hdXRoei5jbG91ZGVudGl0eS5pby9vYXV0aDJjL2RlbW8iLCJqdGkiOiJjODY4NDAxMS0xMTc3LTQ1NmYtYTc5My1lOTMyMmRmZGRlZWMiLCJuYmYiOjE2OTU5OTIzOTAsInNjcCI6WyJlbWFpbCIsIm9mZmxpbmVfYWNjZXNzIiwib3BlbmlkIl0sInN0IjoicHVibGljIiwic3ViIjoiMGZmM2Y4N2NlNzE5YWQyMmFmZjNjMDQwN2EyNWM4N2MzZDhjMmZlN2Y3NDhlYWQ3OTkwZjI2ZDM3NzE4YTg1NiIsInRpZCI6Im9hdXRoMmMifQ.tWHwunTLBIcoeeAW2EAaVvb1ekM_N_9zKVJzXQkHLXOGAJhroyVYjTCPNl0UOxdF84qBsq0Z8qJ4CtNeVQwDCv3tJ3zfTa_2g8RlaASgdn018ATXgutOJmzjmNHyn1USgh5GeUs7CojZBtYA-FrU1E4MidhHGfJDL1k1zsLjzTC-Nw1qnago5gSX6RBH6JYJSIZR-kbwGGR7ywOp6_DmJH6YzOAtUblxzUX45VU2SVJE0ESI1dkgWrE-U6YT3-iPVW5GBclxTthrIJMvyq2KjPoPxGuPyCdz0UGTT_bBiiNHbu1X_kuoR0ghCI5QGCQWm8pq2r8PrzDVlRjuslcwkw
```