### PR TITLE
Add browser timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The available flags are:
       --assertion string            claims for jwt bearer assertion
       --audience strings            requested audience
       --auth-method string          token endpoint authentication method
+      --callback-timeout duration   callback timeout (default 10m0s)
       --claims string               use claims
       --client-id string            client identifier
       --client-secret string        client secret

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The available flags are:
       --assertion string            claims for jwt bearer assertion
       --audience strings            requested audience
       --auth-method string          token endpoint authentication method
-      --callback-timeout duration   callback timeout (default 10m0s)
+      --browser-timeout duration    browser timeout (default 10m0s)
       --claims string               use claims
       --client-id string            client identifier
       --client-secret string        client secret
@@ -89,6 +89,7 @@ The available flags are:
       --encryption-key string       path or url to encryption key in jwks format
       --grant-type string           grant type
   -h, --help                        help for oauthc
+      --http-timeout duration       http client timeout (default 1m0s)
       --id-token-hint string        id token hint
       --idp-hint string             identity provider hint
       --insecure                    allow insecure connections
@@ -107,7 +108,6 @@ The available flags are:
   -s, --silent                      silent mode
       --subject-token string        third party token
       --subject-token-type string   third party token type
-      --timeout duration            http client timeout (default 1m0s)
       --tls-cert string             path to tls cert pem file
       --tls-key string              path to tls key pem file
       --tls-root-ca string          path to tls root ca pem file

--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -72,6 +72,7 @@ func NewOAuth2Cmd() (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().StringVar(&cconfig.TLSKey, "tls-key", "", "path to tls key pem file")
 	cmd.PersistentFlags().StringVar(&cconfig.TLSRootCA, "tls-root-ca", "", "path to tls root ca pem file")
 	cmd.PersistentFlags().DurationVar(&cconfig.Timeout, "timeout", time.Minute, "http client timeout")
+	cmd.PersistentFlags().DurationVar(&cconfig.CallbackTimeout, "callback-timeout", 10*time.Minute, "callback timeout")
 	cmd.PersistentFlags().BoolVar(&cconfig.Insecure, "insecure", false, "allow insecure connections")
 	cmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "silent mode")
 	cmd.PersistentFlags().BoolVar(&cconfig.DPoP, "dpop", false, "use DPoP")

--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -71,8 +71,8 @@ func NewOAuth2Cmd() (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().StringVar(&cconfig.TLSCert, "tls-cert", "", "path to tls cert pem file")
 	cmd.PersistentFlags().StringVar(&cconfig.TLSKey, "tls-key", "", "path to tls key pem file")
 	cmd.PersistentFlags().StringVar(&cconfig.TLSRootCA, "tls-root-ca", "", "path to tls root ca pem file")
-	cmd.PersistentFlags().DurationVar(&cconfig.Timeout, "timeout", time.Minute, "http client timeout")
-	cmd.PersistentFlags().DurationVar(&cconfig.CallbackTimeout, "callback-timeout", 10*time.Minute, "callback timeout")
+	cmd.PersistentFlags().DurationVar(&cconfig.HTTPTimeout, "http-timeout", time.Minute, "http client timeout")
+	cmd.PersistentFlags().DurationVar(&cconfig.BrowserTimeout, "browser-timeout", 10*time.Minute, "browser timeout")
 	cmd.PersistentFlags().BoolVar(&cconfig.Insecure, "insecure", false, "allow insecure connections")
 	cmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "silent mode")
 	cmd.PersistentFlags().BoolVar(&cconfig.DPoP, "dpop", false, "use DPoP")
@@ -118,7 +118,7 @@ func (c *OAuth2Cmd) Run(cconfig *oauth2.ClientConfig) func(cmd *cobra.Command, a
 			},
 		}
 
-		hc := &http.Client{Timeout: cconfig.Timeout, Transport: tr}
+		hc := &http.Client{Timeout: cconfig.HTTPTimeout, Transport: tr}
 
 		if cconfig.TLSCert != "" && cconfig.TLSKey != "" {
 			if cert, err = oauth2.ReadKeyPair(cconfig.TLSCert, cconfig.TLSKey, hc); err != nil {

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -87,6 +87,7 @@ type ClientConfig struct {
 	TLSKey                 string
 	TLSRootCA              string
 	Timeout                time.Duration
+	CallbackTimeout        time.Duration
 	DPoP                   bool
 	Claims                 string
 	RAR                    string
@@ -282,9 +283,13 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
+	timeout := time.After(clientConfig.CallbackTimeout)
+
 	select {
 	case <-signalChan:
 		return request, errors.New("interrupted")
+	case <-timeout:
+		return request, errors.New("timeout")
 	case <-done:
 		return request, err
 	}

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -86,8 +86,8 @@ type ClientConfig struct {
 	TLSCert                string
 	TLSKey                 string
 	TLSRootCA              string
-	Timeout                time.Duration
-	CallbackTimeout        time.Duration
+	HTTPTimeout            time.Duration
+	BrowserTimeout         time.Duration
 	DPoP                   bool
 	Claims                 string
 	RAR                    string
@@ -283,7 +283,7 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
-	timeout := time.After(clientConfig.CallbackTimeout)
+	timeout := time.After(clientConfig.BrowserTimeout)
 
 	select {
 	case <-signalChan:


### PR DESCRIPTION
#74 Added `--browser-timeout 5m` flag. Renamed current timeout (default 1m) to --http-timeout

```
oauth2c on  feature/callback-timeout [$!?] via 🐹 v1.21.0
❯ go run . https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
  --client-id cauktionbud6q8ftlqq0 \
  --client-secret HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc \
  --response-types code \
  --response-mode query --callback-timeout 10s \
  --grant-type authorization_code \
  --auth-method client_secret_basic \
  --scopes openid,email,offline_access
┌───────────────────────────────────────────────────────────────────────┐
| Issuer URL     | https://oauth2c.us.authz.cloudentity.io/oauth2c/demo |
| Grant type     | authorization_code                                   |
| Auth method    | client_secret_basic                                  |
| Scopes         | openid, email, offline_access                        |
| Response types | code                                                 |
| Response mode  | query                                                |
| PKCE           | false                                                |
| Client ID      | cauktionbud6q8ftlqq0                                 |
| Client secret  | HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc          |
└───────────────────────────────────────────────────────────────────────┘


                                                                                                    Authorization Code Flow


# Request authorization

GET https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize
Query params:
  scope: openid email offline_access
  state: nDLeQzJphepWpxVbZympud
  client_id: cauktionbud6q8ftlqq0
  nonce: L4EkCd6M2RRBNzb3fc7tPu
  redirect_uri: http://localhost:9876/callback
  response_mode: query
  response_type: code

Open the following URL:

https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize?client_id=cauktionbud6q8ftlqq0&nonce=L4EkCd6M2RRBNzb3fc7tPu&redirect_uri=http%3A%2F%2Flocalhost%3A9876%2Fcallback&response_mode=query&response_type=code&scope=openid+email+offline_access&state=nDLeQzJphepWpxVbZympud



  ERROR   timeout
exit status 1
```