### PR TITLE
Refactor interruption

### DIFF
--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -9,11 +9,8 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/go-jose/go-jose/v3"
@@ -279,12 +276,7 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 		}
 	}()
 
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
-
 	select {
-	case <-signalChan:
-		return request, errors.New("interrupted")
 	case <-done:
 		return request, err
 	}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,23 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/cloudentity/oauth2c/cmd"
+	"github.com/pterm/pterm"
 )
+
+func init() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-c
+		pterm.Error.Println("Interrupted")
+		os.Exit(1)
+	}()
+}
 
 func main() {
 	if err := cmd.NewOAuth2Cmd().Execute(); err != nil {


### PR DESCRIPTION
Move the INT and TERM signals handling from WaitForCallback to main() so it is always applied