### PR TITLE
Change the CLI name to match the project name

### DIFF
--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cli/browser"
 	"github.com/cloudentity/oauth2c/internal/oauth2"
 	"github.com/imdario/mergo"
-	"github.com/cli/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +32,7 @@ func NewOAuth2Cmd() (cmd *OAuth2Cmd) {
 
 	cmd = &OAuth2Cmd{
 		Command: &cobra.Command{
-			Use:   "oauthc [issuer url]",
+			Use:   "oauth2c [issuer url]",
 			Short: "User-friendly command-line for OAuth2",
 			Args:  cobra.ExactArgs(1),
 		},
@@ -203,7 +203,6 @@ func (c *OAuth2Cmd) Authorize(clientConfig oauth2.ClientConfig, hc *http.Client)
 
 func (c *OAuth2Cmd) PrintResult(result interface{}) {
 	output, err := json.Marshal(result)
-
 	if err != nil {
 		fmt.Fprintf(c.ErrOrStderr(), "%+v", err)
 		fmt.Fprintln(c.ErrOrStderr())


### PR DESCRIPTION
## Background

`oauth2c` uses [cobra](https://github.com/cloudentity/oauth2c/compare/github.com/spf13/cobra) as the CLI framework and [GoReleaser](https://goreleaser.com/) for releases.

- `cobra` uses the _first word_ of the root command's `Use` field to determine the name of the CLI command.
- `GoReleaser` uses the `project_name` variable in the `.goreleaser.yaml` file or an inferred name from the GitHub release to pick the project name.

## Problem

I believe at some point the project was migrated from _cloudentity/oauthc_ to _cloudentity/oauth2c_. However, the name of the CLI was kept the same with the migration. So, GoReleaser has automatically changed to release `oauth2c` under the new name, but cobra is still using the old name.

The name mismatch isn't much of a problem for most use cases. But, primarily for cobra built-in functionality, where the cobra name is used (e.g. `--help`, completions, etc.), the name mismatch leads to incorrect behaviour, such as completions not working since they're generated with the wrong name.

## Solution

Quite a long-winded explanation for a _single character_ change 😅 but it's pretty straightforward; I've just added the missing `2` from the name in the `Use` field for the root command to match the binary name.