### PR TITLE
Add Origin header for Azure SPA authorization code flow with PKCE

### DIFF
--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -465,6 +465,11 @@ func RequestToken(
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	var redirectURL *url.URL
+	if redirectURL, err = url.Parse(cconfig.RedirectURL); err != nil {
+		return request, response, err
+	}
+	req.Header.Add("Origin", redirectURL.Scheme+"://"+redirectURL.Host)
 
 	if cconfig.DPoP {
 		if err = DPoPSignRequest(cconfig.SigningKey, hc, req); err != nil {


### PR DESCRIPTION
I was trying to use the authorization code flow with PKCE an no _client secret_ to retreive an access token from Azure EntraID with a Single-page application (SPA) configured for the redirect URI back to oauth2 at `http://localhost:9876/callback`:

```code
./oauth2c "https://login.microsoftonline.com/${AZURE_TENANT_ID}/v2.0" \
  --pkce \
  --audience "api://myapp" \
  --client-id "${AZURE_CLIENT_ID}" \
  --response-types code \
  --response-mode query \
  --grant-type authorization_code \
  --auth-method none \
  --scopes "api://myapp/Some.Scope"
```

The error message from azure was: `"AADSTS9002327: Tokens issued for the 'Single-Page Application' client-type may only be redeemed via cross-origin requests.`

Apparently you have to include the Origin request header. 

Initial hint from stackoverflow: https://stackoverflow.com/questions/61231144/getting-access-tokens-from-postman-tokens-issued-for-the-single-page-applicati

Also documented at microsoft: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#redirect-uri-setup-required-for-single-page-apps:

> "Applications can't use a spa redirect URI with non-SPA flows, for example, native applications or client credential flows. To ensure security and best practices, the Microsoft identity platform returns an error if you attempt to use a spa redirect URI without an Origin header. Similarly, the Microsoft identity platform also prevents the use of client credentials in all flows in the presence of an Origin header, to ensure that secrets aren't used from within the browser."

This patch adds the necessary request header and with it my oauth2c command is able to retreive an access token.
Since I am not a core maintainer of this project there might be issues with this patch and even a better way to implement it... 