### PR TITLE
Make it possible to configure server endpoints manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,45 +83,54 @@ oauth2c [issuer url] [flags]
 The available flags are:
 
 ```sh
-      --acr-values strings          ACR values
-      --actor-token string          acting party token
-      --actor-token-type string     acting party token type
-      --assertion string            claims for jwt bearer assertion
-      --audience strings            requested audience
-      --auth-method string          token endpoint authentication method
-      --browser-timeout duration    browser timeout (default 10m0s)
-      --claims string               use claims
-      --client-id string            client identifier
-      --client-secret string        client secret
-      --dpop                        use DPoP
-      --encrypted-request-object    pass request parameters as encrypted jwt
-      --encryption-key string       path or url to encryption key in jwks format
-      --grant-type string           grant type
-  -h, --help                        help for oauthc
-      --http-timeout duration       http client timeout (default 1m0s)
-      --id-token-hint string        id token hint
-      --idp-hint string             identity provider hint
-      --insecure                    allow insecure connections
-      --login-hint string           user identifier hint
-      --no-prompt                   disable prompt
-      --par                         enable pushed authorization requests (PAR)
-      --password string             resource owner password credentials grant flow password
-      --pkce                        enable proof key for code exchange (PKCE)
-      --rar string                  use rich authorization request (RAR)
-      --redirect-url string         client redirect url (default "http://localhost:9876/callback")
-      --refresh-token string        refresh token
-      --request-object              pass request parameters as jwt
-      --response-mode string        response mode
-      --response-types strings      response type
-      --scopes strings              requested scopes
-      --signing-key string          path or url to signing key in jwks format
-  -s, --silent                      silent mode
-      --subject-token string        third party token
-      --subject-token-type string   third party token type
-      --tls-cert string             path to tls cert pem file
-      --tls-key string              path to tls key pem file
-      --tls-root-ca string          path to tls root ca pem file
-      --username string             resource owner password credentials grant flow username
+      --acr-values strings                                  ACR values
+      --actor-token string                                  acting party token
+      --actor-token-type string                             acting party token type
+      --assertion string                                    claims for jwt bearer assertion
+      --audience strings                                    requested audience
+      --auth-method string                                  token endpoint authentication method
+      --authorization-endpoint string                       server's authorization endpoint
+      --browser-timeout duration                            browser timeout (default 10m0s)
+      --callback-tls-cert string                            path to callback tls cert pem file
+      --callback-tls-key string                             path to callback tls key pem file
+      --claims string                                       use claims
+      --client-id string                                    client identifier
+      --client-secret string                                client secret
+      --device-authorization-endpoint string                server's device authorization endpoint
+      --dpop                                                use DPoP
+      --encrypted-request-object                            pass request parameters as encrypted jwt
+      --encryption-key string                               path or url to encryption key in jwks format
+      --grant-type string                                   grant type
+  -h, --help                                                help for oauth2c
+      --http-timeout duration                               http client timeout (default 1m0s)
+      --id-token-hint string                                id token hint
+      --idp-hint string                                     identity provider hint
+      --insecure                                            allow insecure connections
+      --login-hint string                                   user identifier hint
+      --mtls-pushed-authorization-request-endpoint string   server's mtls pushed authorization request endpoint
+      --mtls-token-endpoint string                          server's mtls token endpoint
+      --no-prompt                                           disable prompt
+      --par                                                 enable pushed authorization requests (PAR)
+      --password string                                     resource owner password credentials grant flow password
+      --pkce                                                enable proof key for code exchange (PKCE)
+      --purpose string                                      string describing the purpose for obtaining End-User authorization
+      --pushed-authorization-request-endpoint string        server's pushed authorization request endpoint
+      --rar string                                          use rich authorization request (RAR)
+      --redirect-url string                                 client redirect url (default "http://localhost:9876/callback")
+      --refresh-token string                                refresh token
+      --request-object                                      pass request parameters as jwt
+      --response-mode string                                response mode
+      --response-types strings                              response type
+      --scopes strings                                      requested scopes
+      --signing-key string                                  path or url to signing key in jwks format
+  -s, --silent                                              silent mode
+      --subject-token string                                third party token
+      --subject-token-type string                           third party token type
+      --tls-cert string                                     path to tls cert pem file
+      --tls-key string                                      path to tls key pem file
+      --tls-root-ca string                                  path to tls root ca pem file
+      --token-endpoint string                               server's token endpoint
+      --username string                                     resource owner password credentials grant flow username
 ```
 
 `oauth2c` opens a browser for flows such as authorization code and starts an
@@ -708,6 +717,22 @@ oauth2c https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
   --redirect-url https://localhost:9876/callback \
   --callback-tls-cert https://raw.githubusercontent.com/cloudentity/oauth2c/master/data/cert.pem \
   --callback-tls-key https://raw.githubusercontent.com/cloudentity/oauth2c/master/data/key.pem
+```
+
+#### Specifying Authorization Server's Endpoint Manually
+
+If your authorization server does not support OIDC, you can specify the endpoint manually using flags. 
+
+```sh
+oauth2c https://oauth2c.us.authz.cloudentity.io/oauth2c/demo \
+  --client-id cauktionbud6q8ftlqq0 \
+  --client-secret HCwQ5uuUWBRHd04ivjX5Kl0Rz8zxMOekeLtqzki0GPc \
+  --response-types code \
+  --response-mode query \
+  --grant-type authorization_code \
+  --auth-method client_secret_basic \
+  --token-endpoint https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/token \
+  --authorization-endpoint https://oauth2c.us.authz.cloudentity.io/oauth2c/demo/oauth2/authorize
 ```
 
 ## License

--- a/internal/oauth2/jwt.go
+++ b/internal/oauth2/jwt.go
@@ -102,7 +102,7 @@ func RequestObjectClaims(params url.Values, serverConfig ServerConfig, clientCon
 	return func() (map[string]interface{}, error) {
 		claims := map[string]interface{}{
 			"iss": clientConfig.ClientID,
-			"aud": serverConfig.Issuer,
+			"aud": clientConfig.IssuerURL,
 			"exp": time.Now().Add(time.Minute * 10).Unix(),
 			"nbf": time.Now().Unix(),
 		}

--- a/internal/oauth2/jwt_test.go
+++ b/internal/oauth2/jwt_test.go
@@ -15,10 +15,10 @@ func TestSignJWT(t *testing.T) {
 
 	claims := AssertionClaims(
 		ServerConfig{
-			Issuer:        "https://example.com/tid/aid",
 			TokenEndpoint: "https://example.com/tid/aid/oauth2/token",
 		},
 		ClientConfig{
+			IssuerURL: "https://example.com/tid/aid",
 			Assertion: `{"sub": "jdoe@example.com"}`,
 		},
 	)

--- a/internal/oauth2/oauth2_device.go
+++ b/internal/oauth2/oauth2_device.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type DeviceAuthorizationResponse struct {
@@ -23,6 +25,10 @@ func RequestDeviceAuthorization(ctx context.Context, cconfig ClientConfig, sconf
 		req  *http.Request
 		resp *http.Response
 	)
+
+	if sconfig.DeviceAuthorizationEndpoint == "" {
+		return request, response, errors.New("the server's device authorization endpoint is not configured")
+	}
 
 	request.Form = url.Values{
 		"client_id": {cconfig.ClientID},

--- a/internal/oauth2/well_known.go
+++ b/internal/oauth2/well_known.go
@@ -9,21 +9,31 @@ import (
 const OpenIDConfigurationPath = "/.well-known/openid-configuration"
 
 type ServerConfig struct {
-	Issuer                             string   `json:"issuer"`
-	JWKsURI                            string   `json:"jwks_uri"`
-	SupportedGrantTypes                []string `json:"grant_types_supported"`
-	SupportedResponseTypes             []string `json:"response_types_supported"`
-	SupportedTokenEndpointAuthMethods  []string `json:"token_endpoint_auth_methods_supported"`
-	SupportedScopes                    []string `json:"scopes_supported"`
-	SupportedResponseModes             []string `json:"response_modes_supported"`
-	AuthorizationEndpoint              string   `json:"authorization_endpoint"`
-	DeviceAuthorizationEndpoint        string   `json:"device_authorization_endpoint"`
-	PushedAuthorizationRequestEndpoint string   `json:"pushed_authorization_request_endpoint"`
-	TokenEndpoint                      string   `json:"token_endpoint"`
+	SupportedGrantTypes               []string `json:"grant_types_supported"`
+	SupportedResponseTypes            []string `json:"response_types_supported"`
+	SupportedTokenEndpointAuthMethods []string `json:"token_endpoint_auth_methods_supported"`
+	SupportedScopes                   []string `json:"scopes_supported"`
+	SupportedResponseModes            []string `json:"response_modes_supported"`
+
+	AuthorizationEndpoint              string `json:"authorization_endpoint"`
+	DeviceAuthorizationEndpoint        string `json:"device_authorization_endpoint"`
+	PushedAuthorizationRequestEndpoint string `json:"pushed_authorization_request_endpoint"`
+	TokenEndpoint                      string `json:"token_endpoint"`
 	MTLsEndpointAliases                struct {
 		TokenEndpoint                      string `json:"token_endpoint"`
 		PushedAuthorizationRequestEndpoint string `json:"pushed_authorization_request_endpoint"`
 	} `json:"mtls_endpoint_aliases"`
+
+	JWKsURI string `json:"jwks_uri"`
+}
+
+func (c ServerConfig) IsConfigured() bool {
+	return c.AuthorizationEndpoint != "" ||
+		c.DeviceAuthorizationEndpoint != "" ||
+		c.PushedAuthorizationRequestEndpoint != "" ||
+		c.TokenEndpoint != "" ||
+		c.MTLsEndpointAliases.TokenEndpoint != "" ||
+		c.MTLsEndpointAliases.PushedAuthorizationRequestEndpoint != ""
 }
 
 func FetchOpenIDConfiguration(ctx context.Context, issuerURL string, hc *http.Client) (request Request, c ServerConfig, err error) {


### PR DESCRIPTION
Adding the following flags which can be used to configure server's endpoints

```
      --authorization-endpoint string                       server's authorization endpoint
      --device-authorization-endpoint string                server's device authorization endpoint
      --mtls-pushed-authorization-request-endpoint string   server's mtls pushed authorization request endpoint
      --mtls-token-endpoint string                          server's mtls token endpoint
      --pushed-authorization-request-endpoint string        server's pushed authorization request endpoint
      --token-endpoint string                               server's token endpoint
```

If any of those flags is set, then the oauth2c do not call the .well-known/openid-configuration endpoint