### PR TITLE
Support expires_in as a number or string

### DIFF
--- a/internal/oauth2/oauth2_test.go
+++ b/internal/oauth2/oauth2_test.go
@@ -1,0 +1,54 @@
+package oauth2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudentity/oauth2c/internal/oauth2"
+)
+
+func TestUnmarshalExpires(t *testing.T) {
+	tests := map[string]struct {
+		bytes         []byte
+		expectedValue oauth2.FlexibleInt64
+		expectedErr   error
+	}{
+		"number": {
+			bytes:         []byte(`{"expires_in": 3600}`),
+			expectedValue: 3600,
+			expectedErr:   nil,
+		},
+		"number string": {
+			bytes:         []byte(`{"expires_in": "3600"}`),
+			expectedValue: 3600,
+			expectedErr:   nil,
+		},
+		"null": {
+			bytes:         []byte(`{"expires_in": null}`),
+			expectedValue: 0,
+			expectedErr:   nil,
+		},
+		"other string": {
+			bytes:         []byte(`{"expires_in": "foo"}`),
+			expectedValue: 0,
+			expectedErr:   errors.New("invalid syntax"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tokenResponse := oauth2.TokenResponse{}
+			err := json.Unmarshal(test.bytes, &tokenResponse)
+			if test.expectedErr != nil {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedValue, tokenResponse.ExpiresIn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Attempting to get a refresh_token from login.microsoft.com would result
in the following error message.

    failed to parse exchange response: json: cannot unmarshal string into Go struct field TokenResponse.expires_in of type int64

This happens because their API is returning `expires_in` as a JSON
string instead of as a JSON number as expected. It seems this is in
violation of the OAuth2 spec, but it's happening nonetheless.

This change allows `expires_in` to be accepted as an int64 whether it's
encoded as a JSON number or string.
