### PR TITLE
Add "no-browser" flag to prevent automatically opening the browser

### DIFF
--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -81,6 +81,7 @@ func NewOAuth2Cmd(version, commit, date string) (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().DurationVar(&cconfig.BrowserTimeout, "browser-timeout", 10*time.Minute, "browser timeout")
 	cmd.PersistentFlags().BoolVar(&cconfig.Insecure, "insecure", false, "allow insecure connections")
 	cmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "silent mode")
+	cmd.PersistentFlags().BoolVar(&cconfig.NoBrowser, "no-browser", false, "do not open browser")
 	cmd.PersistentFlags().BoolVar(&noPrompt, "no-prompt", false, "disable prompt")
 	cmd.PersistentFlags().BoolVar(&cconfig.DPoP, "dpop", false, "use DPoP")
 	cmd.PersistentFlags().StringVar(&cconfig.Claims, "claims", "", "use claims")

--- a/cmd/oauth2_authorize_code.go
+++ b/cmd/oauth2_authorize_code.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/cloudentity/oauth2c/internal/oauth2"
 	"github.com/cli/browser"
+	"github.com/cloudentity/oauth2c/internal/oauth2"
 )
 
 func (c *OAuth2Cmd) AuthorizationCodeGrantFlow(clientConfig oauth2.ClientConfig, serverConfig oauth2.ServerConfig, hc *http.Client) error {
@@ -54,10 +54,13 @@ func (c *OAuth2Cmd) AuthorizationCodeGrantFlow(clientConfig oauth2.ClientConfig,
 		LogBox("PKCE", "code_verifier = %s\ncode_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))", codeVerifier)
 	}
 
-	Logfln("\nOpen the following URL:\n\n%s\n", authorizeRequest.URL.String())
+	Logfln("\nGo the following URL:\n\n%s\n", authorizeRequest.URL.String())
 
-	if err = browser.OpenURL(authorizeRequest.URL.String()); err != nil {
-		LogError(err)
+	if !clientConfig.NoBrowser {
+		Logfln("Opening browser...\n")
+		if err = browser.OpenURL(authorizeRequest.URL.String()); err != nil {
+			LogError(err)
+		}
 	}
 
 	Logln()

--- a/cmd/oauth2_authorize_code.go
+++ b/cmd/oauth2_authorize_code.go
@@ -54,7 +54,7 @@ func (c *OAuth2Cmd) AuthorizationCodeGrantFlow(clientConfig oauth2.ClientConfig,
 		LogBox("PKCE", "code_verifier = %s\ncode_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))", codeVerifier)
 	}
 
-	Logfln("\nGo the following URL:\n\n%s\n", authorizeRequest.URL.String())
+	Logfln("\nGo to the following URL:\n\n%s\n", authorizeRequest.URL.String())
 
 	if !clientConfig.NoBrowser {
 		Logfln("Opening browser...\n")

--- a/cmd/oauth2_device.go
+++ b/cmd/oauth2_device.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cloudentity/oauth2c/internal/oauth2"
 	"github.com/cli/browser"
+	"github.com/cloudentity/oauth2c/internal/oauth2"
 )
 
 func (c *OAuth2Cmd) DeviceGrantFlow(clientConfig oauth2.ClientConfig, serverConfig oauth2.ServerConfig, hc *http.Client) error {
@@ -31,10 +31,13 @@ func (c *OAuth2Cmd) DeviceGrantFlow(clientConfig oauth2.ClientConfig, serverConf
 
 	LogRequestAndResponse(authorizationRequest, authorizationResponse)
 
-	Logfln("\nOpen the following URL:\n\n%s\n", authorizationResponse.VerificationURIComplete)
+	Logfln("\nGo the following URL:\n\n%s\n", authorizationResponse.VerificationURIComplete)
 
-	if err = browser.OpenURL(authorizationResponse.VerificationURIComplete); err != nil {
-		LogError(err)
+	if !clientConfig.NoBrowser {
+		Logfln("Opening browser...\n")
+		if err = browser.OpenURL(authorizationResponse.VerificationURIComplete); err != nil {
+			LogError(err)
+		}
 	}
 
 	Logln()

--- a/cmd/oauth2_device.go
+++ b/cmd/oauth2_device.go
@@ -31,7 +31,7 @@ func (c *OAuth2Cmd) DeviceGrantFlow(clientConfig oauth2.ClientConfig, serverConf
 
 	LogRequestAndResponse(authorizationRequest, authorizationResponse)
 
-	Logfln("\nGo the following URL:\n\n%s\n", authorizationResponse.VerificationURIComplete)
+	Logfln("\nGo to the following URL:\n\n%s\n", authorizationResponse.VerificationURIComplete)
 
 	if !clientConfig.NoBrowser {
 		Logfln("Opening browser...\n")

--- a/cmd/oauth2_implicit.go
+++ b/cmd/oauth2_implicit.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"net/http"
 
-	"github.com/cloudentity/oauth2c/internal/oauth2"
 	"github.com/cli/browser"
+	"github.com/cloudentity/oauth2c/internal/oauth2"
 )
 
 func (c *OAuth2Cmd) ImplicitGrantFlow(clientConfig oauth2.ClientConfig, serverConfig oauth2.ServerConfig, hc *http.Client) error {
@@ -25,10 +25,13 @@ func (c *OAuth2Cmd) ImplicitGrantFlow(clientConfig oauth2.ClientConfig, serverCo
 
 	LogRequest(authorizeRequest)
 
-	Logfln("\nOpen the following URL:\n\n%s\n", authorizeRequest.URL.String())
+	Logfln("\nGo the following URL:\n\n%s\n", authorizeRequest.URL.String())
 
-	if err = browser.OpenURL(authorizeRequest.URL.String()); err != nil {
-		LogError(err)
+	if !clientConfig.NoBrowser {
+		Logfln("Opening browser...\n")
+		if err = browser.OpenURL(authorizeRequest.URL.String()); err != nil {
+			LogError(err)
+		}
 	}
 
 	Logln()

--- a/cmd/oauth2_implicit.go
+++ b/cmd/oauth2_implicit.go
@@ -25,7 +25,7 @@ func (c *OAuth2Cmd) ImplicitGrantFlow(clientConfig oauth2.ClientConfig, serverCo
 
 	LogRequest(authorizeRequest)
 
-	Logfln("\nGo the following URL:\n\n%s\n", authorizeRequest.URL.String())
+	Logfln("\nGo to the following URL:\n\n%s\n", authorizeRequest.URL.String())
 
 	if !clientConfig.NoBrowser {
 		Logfln("Opening browser...\n")

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -88,6 +88,7 @@ type ClientConfig struct {
 	CallbackTLSKey         string `validate:"omitempty,uri|file"`
 	HTTPTimeout            time.Duration
 	BrowserTimeout         time.Duration
+	NoBrowser              bool
 	DPoP                   bool
 	Claims                 string `validate:"omitempty,json"`
 	RAR                    string `validate:"omitempty,json"`


### PR DESCRIPTION
Fixes #114.

In a headless environment, trying to open a browser will always fail, showing a message in red like:
```
  ERROR   exec: "xdg-open,x-www-browser,www-browser,wslview": executable file not found in $PATH
```

This PR makes it possible to call `oauth2c` with a flag to prevent that behaviour.