### PR TITLE
Avoid "listen tcp: address localhost: missing port in address"

### DIFF
--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -233,6 +233,13 @@ func WaitForCallback(clientConfig ClientConfig, serverConfig ServerConfig, hc *h
 		srv.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
 		}
+		if redirectURL.Port() == "" {
+			srv.Addr += ":443"
+		}
+	} else {
+		if redirectURL.Port() == "" {
+			srv.Addr += ":80"
+		}
 	}
 
 	http.HandleFunc(redirectURL.Path, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
When using http://localhost or https://localhost as the callback URL
the server stops with the error message:

listen tcp: address localhost: missing port in address