### PR TITLE
Add "no-origin" flag in order to work better with Entra desktop apps

### DIFF
--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -91,6 +91,7 @@ func NewOAuth2Cmd(version, commit, date string) (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().StringSliceVar(&cconfig.Prompt, "prompt", []string{}, "end-user authorization purpose")
 	cmd.PersistentFlags().StringVar(&cconfig.MaxAge, "max-age", "", "maximum authentication age in seconds")
 	cmd.PersistentFlags().StringVar(&cconfig.AuthenticationCode, "authentication-code", "", "authentication code used for passwordless authentication")
+	cmd.PersistentFlags().BoolVar(&cconfig.NoOrigin, "no-origin", false, "do not include an Origin header")
 
 	cmd.PersistentFlags().StringVar(&sconfig.TokenEndpoint, "token-endpoint", "", "server's token endpoint")
 	cmd.PersistentFlags().StringVar(&sconfig.AuthorizationEndpoint, "authorization-endpoint", "", "server's authorization endpoint")

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -54,6 +54,7 @@ var CodeChallengeEncoder = base64.RawURLEncoding
 type ClientConfig struct {
 	IssuerURL              string `validate:"url"`
 	RedirectURL            string `validate:"url"`
+	NoOrigin               bool
 	GrantType              string `validate:"oneof=authorization_code client_credentials implicit password refresh_token urn:ietf:params:oauth:grant-type:jwt-bearer urn:ietf:params:oauth:grant-type:token-exchange urn:ietf:params:oauth:grant-type:device_code"`
 	ClientID               string
 	ClientSecret           string
@@ -536,7 +537,9 @@ func RequestToken(
 			return request, response, err
 		}
 
-		req.Header.Add("Origin", fmt.Sprintf("%s://%s", redirectURL.Scheme, redirectURL.Host))
+		if !cconfig.NoOrigin {
+			req.Header.Add("Origin", fmt.Sprintf("%s://%s", redirectURL.Scheme, redirectURL.Host))
+		}
 	}
 
 	if cconfig.DPoP {


### PR DESCRIPTION
Greetings!

I discovered oauth2c today, and it is was exactly what I was looking for.  

However, I have an app in Entra that is registed as a desktop application that uses the "authorization code flow with PKCE", and I'd like to be able to get an access token for it.

Unfornately, I discoved that 
- Entra interprets the Origin header as an indicator that is a different type of app, returning an error (see **Before** below)
- oauth2c always includes an Origin header when a --redirect-url is specified

In order to help oauth2c support my use case, this PR adds a `--no-origin` flag, to indicate that the Origin header not be emitted (see **After** farther below).  Though, do let me know if they may be another way to handle this, as there could easily be something I've overlooked.

Cheers!

**Before**
```
oauth2c https://login.microsoftonline.com/<redacted> \
  --client-id <redacted> \
  --response-types code \
  --response-mode query \
  --grant-type authorization_code \
  --auth-method none \
  --scopes "<scopes>" \
  --pkce \
  --redirect-url http://localhost:50051/oauth/redirect
``` 
... the response is like so...
```
Response:                                                                                                                                                                           
{                                                                                                                                                                                   
  "error": "invalid_request",
  "error_description": "AADSTS9002326: Cross-origin token redemption is permitted only for the 'Single-Page Application' client-type. Request origin: 'http://localhost:50051'. Trace ID: 787a709b-5a37-41a9-b410-9a2ecedb8100 Correlation ID: 686bfee3-0e2f-48fc-abd7-0fa83caa40f1 Timestamp: 2025-05-22 10:44:42Z"
}
                                                                                                                                                                                    
  ERROR   400: invalid_request         
```

**After: using new --no-origin flag**
```
% go build -o ./oauth2c
% ./oauth2c https://login.microsoftonline.com/<redacted> \
  --client-id <client-id> \
  --response-types code \
  --response-mode query \
  --grant-type authorization_code \
  --auth-method none \
  --scopes "<redacted>" \
  --pkce \
  --redirect-url http://localhost:50051/oauth/redirect
 --no-origin
```

As a result an access token can be successfully obtained for my Entra app:
```
┌─────────────────────────────────────────────────────────────────────────────────────────┐
| Issuer URL     | https://login.microsoftonline.com/<redacted> |
| Grant type     | authorization_code                                                     |
| Auth method    | none                                                                   |
| Scopes         | <redacted>         |
| Response types | code                                                                   |
| Response mode  | query                                                                  |
| PKCE           | true                                                                   |
| Client ID      | <redacted>                                   |
└─────────────────────────────────────────────────────────────────────────────────────────┘

                                                                                                                                                                                    
                                                                              Authorization Code Flow                                                                               
                                                                                                                                                                                    

# Request authorization

GET https://login.microsoftonline.com/<redacted>/oauth2/authorize
Query params:
  nonce: <redacted>
  state: <redacted>
  client_id: <redacted>
  redirect_uri: http://localhost:50051/oauth/redirect
  response_mode: query
  response_type: code
  scope: <redacted>
  code_challenge: <redacted>
  code_challenge_method: S256

┌─ PKCE ──────────────────────────────────────────────────────────┐
| code_verifier = <redacted>     |
| code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) |
└─────────────────────────────────────────────────────────────────┘

Go to the following URL:

https://login.microsoftonline.com/<redacted>/oauth2/authorize?client_id=<redacted>

Opening browser...

GET /oauth/redirect                                                                                                                                                                 
Query params:                                                                                                                                                                       
<redacted>                                                                                                                             
                                                                                                                                                                                    
 SUCCESS  Obtained authorization code                                                                                                                                               


# Exchange authorization code for token

POST https://login.microsoftonline.com/<redacted>/oauth2/token                                                                                            
Headers:                                                                                                                                                                            
  Content-Type: application/x-www-form-urlencoded                                                                                                                                   
Form post:                                                                                                                                                                          
  grant_type: authorization_code                                                                                                                                                    
  client_id: 7dfaabe0-f70a-4ca6-9f7b-a3c5303f4071                                                                                                                                   
  redirect_uri: http://localhost:50051/oauth/redirect                                                                                                                               
  code: <redacted>                                                                                                                       
Response:                                                                                                                                                                           
{                                                                                                                                                                                   
  "access_token": "<redacted>",
  "expires_in": 4655,
  "id_token": "<redacted>",
  "refresh_token": "<redacted>",
  "scope": "<redacted>",
  "token_type": "Bearer"
}
Access token:                                                                                                                                                                       
{                                                                                                                                                                                   
<redacted>
}
ID token:                                                                                                                                                                           
{                                                                                                                                                                                   
<redacted>
}
                                                                                                                                                                                    
 SUCCESS  Exchanged authorization code for access token                                                                                                                             

{"access_token":"<redacted>","expires_in":4655,"id_token":"<redacted>,"scope":"<redacted>","token_type":"Bearer"}

```