### PR TITLE
Handle optional fields of the Device Authorization Response.

### DIFF
--- a/internal/oauth2/oauth2_device.go
+++ b/internal/oauth2/oauth2_device.go
@@ -12,12 +12,12 @@ import (
 )
 
 type DeviceAuthorizationResponse struct {
-	DeviceCode              string `json:"device_code"`
-	UserCode                string `json:"user_code"`
-	VerificationURI         string `json:"verification_uri"`
-	VerificationURIComplete string `json:"verification_uri_complete"`
-	ExpiresIn               int64  `json:"expires_in"`
-	Interval                int64  `json:"interval"`
+	DeviceCode              string  `json:"device_code"`
+	UserCode                string  `json:"user_code"`
+	VerificationURI         string  `json:"verification_uri"`
+	VerificationURIComplete *string `json:"verification_uri_complete"`
+	ExpiresIn               int64   `json:"expires_in"`
+	Interval                *int64  `json:"interval"`
 }
 
 func RequestDeviceAuthorization(ctx context.Context, cconfig ClientConfig, sconfig ServerConfig, hc *http.Client) (request Request, response DeviceAuthorizationResponse, err error) {


### PR DESCRIPTION
According to the RFC for the Device Authorization Grant, the interval and verification_uri_complete fields are optional. When missing, the interval is assumed to be 5 seconds. If verification_uri_complete is missing, the client should fallback to verification_uri.