### PR TITLE
Use crypto/rand instead of math/rand for random string generation

### DIFF
--- a/internal/oauth2/crypto.go
+++ b/internal/oauth2/crypto.go
@@ -1,23 +1,17 @@
 package oauth2
 
 import (
-	"math/rand"
-	"time"
+	"crypto/rand"
 )
 
-var r *rand.Rand
-
-func init() {
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
-}
-
-var letter = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+var letter = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 func RandomString(n int) string {
-	b := make([]rune, n)
+	b := make([]byte, n)
+	rand.Read(b)
 
 	for i := range b {
-		b[i] = letter[r.Intn(len(letter))]
+		b[i] = letter[b[i]%byte(len(letter))]
 	}
 
 	return string(b)


### PR DESCRIPTION
This adheres to security best practices by using cryptographically secure random values for OAuth2 state parameters and PKCE code verifiers. Resolves #144 