### PR TITLE
Add --raw flag to output unmodified JSON token response

### DIFF
--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -21,6 +21,7 @@ import (
 var (
 	silent   bool
 	noPrompt bool
+	rawJSON  bool
 )
 
 type OAuth2Cmd struct {
@@ -93,6 +94,7 @@ func NewOAuth2Cmd(version, commit, date string) (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().StringVar(&cconfig.MaxAge, "max-age", "", "maximum authentication age in seconds")
 	cmd.PersistentFlags().StringVar(&cconfig.AuthenticationCode, "authentication-code", "", "authentication code used for passwordless authentication")
 	cmd.PersistentFlags().BoolVar(&cconfig.NoOrigin, "no-origin", false, "do not include an Origin header")
+	cmd.PersistentFlags().BoolVar(&rawJSON, "raw", false, "output raw JSON response from the server")
 
 	cmd.PersistentFlags().StringVar(&sconfig.TokenEndpoint, "token-endpoint", "", "server's token endpoint")
 	cmd.PersistentFlags().StringVar(&sconfig.AuthorizationEndpoint, "authorization-endpoint", "", "server's authorization endpoint")
@@ -230,7 +232,12 @@ func (c *OAuth2Cmd) Authorize(
 	return fmt.Errorf("unknown grant type: %s", clientConfig.GrantType)
 }
 
-func (c *OAuth2Cmd) PrintResult(result interface{}) {
+func (c *OAuth2Cmd) PrintResult(result oauth2.TokenResponse) {
+	if rawJSON && result.RawJSON != nil {
+		_, _ = fmt.Fprintln(c.OutOrStdout(), string(result.RawJSON))
+		return
+	}
+
 	output, err := json.Marshal(result)
 	if err != nil {
 		_, _ = fmt.Fprintf(c.ErrOrStderr(), "%+v", err)

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -349,6 +349,7 @@ type TokenResponse struct {
 	Scope                string                   `json:"scope,omitempty"`
 	TokenType            string                   `json:"token_type,omitempty"`
 	AuthorizationDetails []map[string]interface{} `json:"authorization_details,omitempty"`
+	RawJSON              json.RawMessage          `json:"-"`
 }
 
 // FlexibleInt64 is a type that can be unmarshaled from a JSON number or
@@ -581,6 +582,8 @@ func RequestToken(
 	if err = json.Unmarshal(body, &response); err != nil {
 		return request, response, fmt.Errorf("failed to parse exchange response: %w", err)
 	}
+
+	response.RawJSON = json.RawMessage(body)
 
 	return request, response, nil
 }


### PR DESCRIPTION
Preserves the raw JSON bytes from the token endpoint response so that fields not modeled in TokenResponse (e.g. email, environment_id, legal_entity_name) are available when --raw is passed.

My use case for this is that one of the OAuth providers I work with returns some data in the response that is important for my application, for example, in this payload:

```json
{
    "access_token": "token",
    "email": "me@email.com",
    "environment_id": "envid-token-here",
    "environment_name": "oauth environment",
    "expires_in": 3600,
    "family_name": "Smith",
    "given_name": "John",
    "legal_entity_id": "legal-entity-id-token-here",
    "legal_entity_name": "oauth environment provider",
    "mode": "None",
    "refresh_token": "ref-token",
    "refresh_token_expires_in": 31536000,
    "token_type": "Bearer",
    "user_id": "uid-token-here"
  }
```

The `environment` and `legal_entity` fields are important for my application, and they should be retrieved from this endpoint.

I'll understand if there are other concerns (I assume security must be one of them) for not including this in the CLI, but just wanted to float the idea and see the feedback.