### PR TITLE
Add --resource flag for RFC 8707 Resource Indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The available flags are:
       --redirect-url string                                 client redirect url (default "http://localhost:9876/callback")
       --refresh-token string                                refresh token
       --request-object                                      pass request parameters as jwt
+      --resource strings                                    requested resource
       --response-mode string                                response mode
       --response-types strings                              response type
       --scopes strings                                      requested scopes

--- a/cmd/oauth2.go
+++ b/cmd/oauth2.go
@@ -58,6 +58,7 @@ func NewOAuth2Cmd(version, commit, date string) (cmd *OAuth2Cmd) {
 	cmd.PersistentFlags().StringVar(&cconfig.ResponseMode, "response-mode", "", "response mode")
 	cmd.PersistentFlags().StringSliceVar(&cconfig.Scopes, "scopes", []string{}, "requested scopes")
 	cmd.PersistentFlags().StringSliceVar(&cconfig.Audience, "audience", []string{}, "requested audience")
+	cmd.PersistentFlags().StringSliceVar(&cconfig.Resource, "resource", []string{}, "requested resource")
 	cmd.PersistentFlags().BoolVar(&cconfig.PKCE, "pkce", false, "enable proof key for code exchange (PKCE)")
 	cmd.PersistentFlags().BoolVar(&cconfig.PAR, "par", false, "enable pushed authorization requests (PAR)")
 	cmd.PersistentFlags().BoolVar(&cconfig.RequestObject, "request-object", false, "pass request parameters as jwt")

--- a/internal/oauth2/oauth2.go
+++ b/internal/oauth2/oauth2.go
@@ -62,6 +62,7 @@ type ClientConfig struct {
 	Scopes                 []string
 	ACRValues              []string
 	Audience               []string
+	Resource               []string
 	AuthMethod             string `validate:"omitempty,oneof=client_secret_basic client_secret_post client_secret_jwt private_key_jwt self_signed_tls_client_auth tls_client_auth none"`
 	PKCE                   bool
 	PAR                    bool
@@ -510,6 +511,10 @@ func RequestToken(
 
 		if len(cconfig.Audience) > 0 {
 			request.Form.Set("audience", strings.Join(cconfig.Audience, " "))
+		}
+
+		for _, resource := range cconfig.Resource {
+			request.Form.Add("resource", resource)
 		}
 
 		if len(cconfig.RAR) > 0 {

--- a/internal/oauth2/oauth2_device.go
+++ b/internal/oauth2/oauth2_device.go
@@ -42,6 +42,10 @@ func RequestDeviceAuthorization(ctx context.Context, cconfig ClientConfig, sconf
 		request.Form.Set("audience", strings.Join(cconfig.Audience, " "))
 	}
 
+	for _, resource := range cconfig.Resource {
+		request.Form.Add("resource", resource)
+	}
+
 	if req, err = http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,

--- a/internal/oauth2/request.go
+++ b/internal/oauth2/request.go
@@ -57,6 +57,10 @@ func (r *Request) AuthorizeRequest(
 		r.Form.Set("audience", strings.Join(cconfig.Audience, " "))
 	}
 
+	for _, resource := range cconfig.Resource {
+		r.Form.Add("resource", resource)
+	}
+
 	if len(cconfig.Purpose) > 0 {
 		r.Form.Set("purpose", cconfig.Purpose)
 	}
@@ -147,6 +151,10 @@ func (r *Request) AuthorizeRequest(
 
 		if len(cconfig.Audience) > 0 {
 			r.Form.Set("audience", strings.Join(cconfig.Audience, " "))
+		}
+
+		for _, resource := range cconfig.Resource {
+			r.Form.Add("resource", resource)
 		}
 
 		if len(cconfig.Purpose) > 0 {

--- a/internal/oauth2/request_test.go
+++ b/internal/oauth2/request_test.go
@@ -1,0 +1,102 @@
+package oauth2_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudentity/oauth2c/internal/oauth2"
+)
+
+func TestAuthorizeRequestResource(t *testing.T) {
+	tests := map[string]struct {
+		resource []string
+		expected []string
+	}{
+		"none": {
+			resource: nil,
+			expected: nil,
+		},
+		"single": {
+			resource: []string{"https://api.example.com"},
+			expected: []string{"https://api.example.com"},
+		},
+		"multiple": {
+			resource: []string{"https://api.example.com", "https://other.example.com"},
+			expected: []string{"https://api.example.com", "https://other.example.com"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := &oauth2.Request{}
+			cconfig := oauth2.ClientConfig{
+				ClientID:    "test-client",
+				RedirectURL: "http://localhost/callback",
+				Resource:    tc.resource,
+			}
+
+			_, err := r.AuthorizeRequest(cconfig, oauth2.ServerConfig{}, http.DefaultClient)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, r.Form["resource"])
+		})
+	}
+}
+
+func TestRequestTokenResource(t *testing.T) {
+	tests := map[string]struct {
+		resource []string
+		expected []string
+	}{
+		"none": {
+			resource: nil,
+			expected: nil,
+		},
+		"single": {
+			resource: []string{"https://api.example.com"},
+			expected: []string{"https://api.example.com"},
+		},
+		"multiple": {
+			resource: []string{"https://api.example.com", "https://other.example.com"},
+			expected: []string{"https://api.example.com", "https://other.example.com"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got url.Values
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				got, err = url.ParseQuery(string(body))
+				require.NoError(t, err)
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+			}))
+			defer srv.Close()
+
+			cconfig := oauth2.ClientConfig{
+				ClientID:     "test-client",
+				ClientSecret: "test-secret",
+				GrantType:    oauth2.ClientCredentialsGrantType,
+				AuthMethod:   oauth2.ClientSecretPostAuthMethod,
+				Resource:     tc.resource,
+			}
+			sconfig := oauth2.ServerConfig{TokenEndpoint: srv.URL}
+
+			_, _, err := oauth2.RequestToken(context.Background(), cconfig, sconfig, &http.Client{})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, got["resource"])
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for the OAuth 2.0 `resource` request parameter
([RFC 8707 — Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707))
to oauth2c. Mirrors the existing `--audience` plumbing.

- New `--resource` flag (StringSlice, repeatable like `--audience`)
- New `Resource []string` field on `ClientConfig`
- Threads the value into the authorize, token, PAR, and device-authorization
  request bodies/queries
- Multi-value handling uses repeated `resource=` parameters per RFC 8707
  §2 (rather than space-joining), so `--resource A --resource B` produces
  `resource=A&resource=B`
- README flag table updated

## Test plan

- [x] `go test ./...` passes (new unit tests in `internal/oauth2/request_test.go`
      cover empty / single / multiple resource values for both `AuthorizeRequest`
      and `RequestToken`)
- [x] `go build ./...` clean
- [x] `golangci-lint run` clean
- [x] Manually verified against an authorization-code + PKCE flow:
      `--resource <uri>` shows up in the GET to `/authorize` query params
      and the POST to `/token` form body