### PR TITLE
DEVOPS-8397: chore(security): pin external GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'
           cache: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,12 +15,12 @@ jobs:
   golangci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,15 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'
           cache: true
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
## Summary

Pin every **external** third-party GitHub Action to a full-length commit SHA with a
trailing version comment, mitigating the mutable-tag supply-chain attack class
(e.g. the `tj-actions/changed-files` compromise). A moved tag can no longer swap
code into our CI — the SHA is immutable, and the comment preserves the original
version for readability and Renovate updates.

Internal `SecureAuthCorp/*` references are intentionally left on floating tags
(`@main` / `@v1`) — same-org sources where floating is by design and the
external-maintainer threat does not apply.

No functional change: every SHA resolves to the exact commit the existing tag
currently points to.

This mirrors the org `github-actions` repo change (PR #90).

JIRA: https://secureauth.atlassian.net/browse/DEVOPS-8397
