### PR TITLE
DEVOPS-8593: feat: add Dependabot auto-approve workflow

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,13 @@
+name: Dependabot auto-approve
+
+on: pull_request
+
+jobs:
+  auto-approve:
+    permissions:
+      pull-requests: write
+      checks: read
+      statuses: read
+      actions: read
+      contents: read
+    uses: SecureAuthCorp/github-actions/.github/workflows/dependabot-auto-approve.yaml@3891a1c4e9fca203588d0b9906b3b0b1fa862bb5


### PR DESCRIPTION
## Summary

Adds the Dependabot auto-approve caller workflow, rolling out the reusable workflow from `SecureAuthCorp/github-actions` (already in use in faye-server). On Dependabot PRs it verifies all commits are authored by `dependabot[bot]`, waits for the required checks to pass, and approves the PR. Branch protection still applies on top of the bot approval.

The permissions block grants the full set `gh pr checks` needs on Dependabot-triggered runs (`checks`, `statuses`, `actions`, `contents: read` + `pull-requests: write`); an explicit permissions block zeroes out unlisted scopes, and missing `actions: read`/`contents: read` is what broke earlier rollouts (see SecureAuthCorp/faye-server#114, SecureAuthCorp/faye-server#116).

JIRA: https://secureauth.atlassian.net/browse/DEVOPS-8593