### PR TITLE
DEVOPS-8593: fix: approve Dependabot PRs when no required checks are configured

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -29,7 +29,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Wait for required checks to pass
         timeout-minutes: 30
-        run: gh pr checks "$PR_URL" --required --watch --fail-fast
+        run: |
+          set +e
+          output=$(gh pr checks "$PR_URL" --required --watch --fail-fast 2>&1)
+          code=$?
+          set -e
+          echo "$output"
+          if [ $code -ne 0 ] && echo "$output" | grep -qi "no required checks"; then
+            echo "No required checks configured on the base branch; skipping wait."
+            exit 0
+          fi
+          exit $code
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The auto-approve job fails on every Dependabot PR with `no required checks reported` (see [this run](https://github.com/SecureAuthCorp/oauth2c/actions/runs/31162450933)) because `gh pr checks --required` has nothing to watch — master has no required status checks configured.

This makes the wait step tolerate that case: when the only failure reason is that no required checks exist, the job proceeds to approve instead of failing. Genuine check failures and timeouts still fail the job as before.

JIRA: https://secureauth.atlassian.net/browse/DEVOPS-8593